### PR TITLE
feat: enable setting addressIds and estateId on activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## main
+- TODO: Remove old activity repository code in next major release
+
+## v1.5.4
+- enable setting both estateId and addressIds on activity repository
+- deprecates the current way of setting ids on activity repository
+
+## v1.5.3
+- enable search request on estate repository
+
+## v1.5.2
+- fixes user repository find function
+
+## v1.5.1
+- fixes issue where requests with strings as resource types could not be processed when generating the hmac
+
+## v1.5.0
+- feat: enable withCredentials call_ on Builder so config is not needed to set runtime credentials
+
 ## v1.4.4
 - fix type annotation for upload function on file repository
 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ $success = FileRepository::upload()
 ```
 ```php
 ActivityRepository::query()
-    ->recordIds($recordIds)
-    ->recordIdsAsAddress()
+    ->addressIds($recordIds)
+    ->estateId($estateId)
     ->create([
         'datetime' => $event->getDateFormatted(),
         'actionkind' => 'Newsletter',

--- a/docs/ActivityRepository.md
+++ b/docs/ActivityRepository.md
@@ -5,40 +5,28 @@
 use Innobrain\OnOfficeAdapter\Facades\ActivityRepository;
 
 $activities = ActivityRepository::query()
-    ->recordIdsAsAddress()
-    ->recordIdsAsEstate()
-    ->estate()
-    ->address()
-    ->recordIds([1, 2, 3])
+    ->estateId(1)
+    ->get();
+    
+$activities = ActivityRepository::query()
+    ->addressIds([1, 2])
     ->get();
 
 $activity = ActivityRepository::query()
-    ->recordIdsAsAddress()
-    ->recordIdsAsEstate()
-    ->estate()
-    ->address()
-    ->recordIds([1, 2, 3])
+    ->addressIds(1)
     ->first();
 
 $activity = ActivityRepository::query()
     ->find(1);
 
 ActivityRepository::query()
-    ->recordIdsAsAddress()
-    ->recordIdsAsEstate()
-    ->estate()
-    ->address()
-    ->recordIds([1, 2, 3])
+    ->addressIds([1, 2])
     ->each(function (array $estates) {
         // First page
     });
 
 $activity = ActivityRepository::query()
-    ->recordIdsAsAddress()
-    ->recordIdsAsEstate()
-    ->estate()
-    ->address()
-    ->recordIds([1, 2, 3])
+    ->addressIds([1, 2, 3])
     ->create([
         'activity_id' => 1,
     ]);

--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Innobrain\OnOfficeAdapter\Query;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
@@ -19,6 +20,10 @@ class ActivityBuilder extends Builder
 
     public string $estateOrAddress = 'estate';
 
+    public ?int $estateId = null;
+
+    public array $addressIds = [];
+
     /**
      * @throws OnOfficeException
      */
@@ -30,7 +35,7 @@ class ActivityBuilder extends Builder
             OnOfficeAction::Read,
             OnOfficeResourceType::Activity,
             parameters: [
-                $this->estateOrAddress => $this->recordIds,
+                ...$this->prepareEstateOrAddressParameters(),
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
                 OnOfficeService::SORTBY => data_get(array_keys($orderBy), 0),
@@ -53,7 +58,7 @@ class ActivityBuilder extends Builder
             OnOfficeAction::Read,
             OnOfficeResourceType::Activity,
             parameters: [
-                $this->estateOrAddress => $this->recordIds,
+                ...$this->prepareEstateOrAddressParameters(),
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
                 OnOfficeService::LISTLIMIT => $this->limit > 0 ? $this->limit : $this->pageSize,
@@ -102,7 +107,7 @@ class ActivityBuilder extends Builder
             OnOfficeAction::Read,
             OnOfficeResourceType::Activity,
             parameters: [
-                $this->estateOrAddress => $this->recordIds,
+                ...$this->prepareEstateOrAddressParameters(),
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
                 OnOfficeService::SORTBY => $sortBy,
@@ -120,7 +125,7 @@ class ActivityBuilder extends Builder
     public function create(array $data): array
     {
         $data = array_replace($data, [
-            $this->estateOrAddress => $this->recordIds,
+            ...$this->prepareEstateOrAddressParameters(),
         ]);
 
         $request = new OnOfficeRequest(
@@ -133,6 +138,9 @@ class ActivityBuilder extends Builder
             ->json('response.results.0.data.records.0');
     }
 
+    /**
+     * @deprecated Use estateId() instead
+     */
     public function estate(): static
     {
         $this->estateOrAddress = 'estateid';
@@ -140,6 +148,9 @@ class ActivityBuilder extends Builder
         return $this;
     }
 
+    /**
+     * @deprecated Use addressIds() instead
+     */
     public function address(): static
     {
         $this->estateOrAddress = 'addressids';
@@ -147,6 +158,9 @@ class ActivityBuilder extends Builder
         return $this;
     }
 
+    /**
+     * @deprecated Use estateId() instead
+     */
     public function recordIdsAsEstate(): static
     {
         $this->estate();
@@ -154,10 +168,51 @@ class ActivityBuilder extends Builder
         return $this;
     }
 
+    /**
+     * @deprecated Use addressIds() instead
+     */
     public function recordIdsAsAddress(): static
     {
         $this->address();
 
         return $this;
+    }
+
+    public function estateId(int $estateId): static
+    {
+        $this->estateId = $estateId;
+
+        return $this;
+    }
+
+    public function addressIds(int|array $addressIds): static
+    {
+        $this->addressIds = Arr::wrap($addressIds);
+
+        return $this;
+    }
+
+    /**
+     * Function is used to deprecate the usage of recordIdsAsEstate() and recordIdsAsAddress()
+     * without breaking changes.
+     */
+    private function prepareEstateOrAddressParameters(): array
+    {
+        $parameters = [$this->estateOrAddress => $this->recordIds];
+
+        // If the estateOrAddress is set to estate, we know the user has not used the old methods.
+        if ($this->estateOrAddress === 'estate') {
+            $parameters = [];
+        }
+
+        if (! is_null($this->estateId)) {
+            $parameters['estateid'] = $this->estateId;
+        }
+
+        if ($this->addressIds !== []) {
+            $parameters['addressids'] = $this->addressIds;
+        }
+
+        return $parameters;
     }
 }

--- a/tests/Query/ActivityBuilderTest.php
+++ b/tests/Query/ActivityBuilderTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
+use Innobrain\OnOfficeAdapter\Query\ActivityBuilder;
+use Innobrain\OnOfficeAdapter\Repositories\ActivityRepository;
+
+describe('deprecated estate/address methods', function () {
+    it('sets estate parameter correctly', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->estate();
+        $builder->recordIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['estateid' => [1, 2, 3]]);
+    });
+
+    it('sets address parameter correctly', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->address();
+        $builder->recordIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['addressids' => [1, 2, 3]]);
+    });
+
+    it('sets estate parameter via recordIdsAsEstate', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->recordIdsAsEstate();
+        $builder->recordIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['estateid' => [1, 2, 3]]);
+    });
+
+    it('sets address parameter via recordIdsAsAddress', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->recordIdsAsAddress();
+        $builder->recordIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['addressids' => [1, 2, 3]]);
+    });
+});
+
+describe('new estate/address methods', function () {
+    it('sets estateId parameter correctly', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->estateId(123);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['estateid' => 123]);
+    });
+
+    it('sets addressIds parameter correctly with single ID', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->addressIds(123);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['addressids' => [123]]);
+    });
+
+    it('sets addressIds parameter correctly with array of IDs', function () {
+        $builder = new ActivityBuilder;
+
+        $builder->addressIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe(['addressids' => [1, 2, 3]]);
+    });
+
+    it('combines estateId and addressIds parameters correctly', function () {
+        $builder = new ActivityBuilder;
+
+        $builder
+            ->estateId(123)
+            ->addressIds([1, 2, 3]);
+
+        $m = new ReflectionMethod($builder, 'prepareEstateOrAddressParameters');
+        $m->setAccessible(true);
+        $parameters = $m->invoke($builder);
+
+        expect($parameters)->toBe([
+            'estateid' => 123,
+            'addressids' => [1, 2, 3],
+        ]);
+    });
+});
+
+describe('CRUD operations', function () {
+    beforeEach(function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php/' => Http::response([
+                'status' => [
+                    'code' => 200,
+                ],
+                'response' => [
+                    'results' => [
+                        [
+                            'data' => [
+                                'records' => [
+                                    ['id' => 1, 'type' => 'activity'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+    });
+
+    it('creates activity with estate parameters', function () {
+        $builder = new ActivityBuilder;
+
+        $builder
+            ->setRepository(new ActivityRepository)
+            ->estateId(123)
+            ->create(['note' => 'Test activity']);
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'request.actions.0.parameters.estateid') === 123
+                && data_get($body, 'request.actions.0.parameters.note') === 'Test activity';
+        });
+    });
+
+    it('gets activities with combined parameters', function () {
+        $builder = new ActivityBuilder;
+
+        $builder
+            ->setRepository(new ActivityRepository)
+            ->estateId(123)
+            ->addressIds([1, 2])
+            ->get();
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'request.actions.0.parameters.estateid') === 123
+                && data_get($body, 'request.actions.0.parameters.addressids') === [1, 2]
+                && data_get($body, 'request.actions.0.actionid') === OnOfficeAction::Read->value
+                && data_get($body, 'request.actions.0.resourcetype') === OnOfficeResourceType::Activity->value;
+        });
+    });
+});


### PR DESCRIPTION
- also soft-deprecates the old way of doing things

# Desc
Before, you needed to use the BaseRepository to be able to create an Activity that is linked to both an estate and adresses.
This PR changes that, while not breaking the current way of doing things. The current way is soft-deprecated and deprecation notices are added.