### PR TITLE
fix: rename 'addressids' parameter to 'addressid' for ActivityBuilder

### DIFF
--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -125,7 +125,7 @@ class ActivityBuilder extends Builder
     public function create(array $data): array
     {
         $data = array_replace($data, [
-            ...$this->prepareEstateOrAddressParameters(),
+            ...$this->prepareEstateOrAddressParameters(create: true),
         ]);
 
         $request = new OnOfficeRequest(
@@ -220,7 +220,7 @@ class ActivityBuilder extends Builder
      * Function is used to deprecate the usage of recordIdsAsEstate() and recordIdsAsAddress()
      * without breaking changes.
      */
-    private function prepareEstateOrAddressParameters(): array
+    private function prepareEstateOrAddressParameters(bool $create = false): array
     {
         $parameters = [$this->estateOrAddress => $this->recordIds];
 
@@ -234,7 +234,12 @@ class ActivityBuilder extends Builder
         }
 
         if ($this->addressIds !== []) {
-            $parameters['addressid'] = $this->addressIds;
+            $key = match ($create) {
+                true => 'addressids',
+                false => 'addressid',
+            };
+
+            $parameters[$key] = $this->addressIds;
         }
 
         return $parameters;


### PR DESCRIPTION
This pull request updates the `ActivityBuilder` class to improve the handling of address IDs when creating activities and adds corresponding test cases to ensure the changes work as expected. The most significant updates include modifying the `prepareEstateOrAddressParameters` method to accept a `create` flag, updating the logic for setting the address parameter key based on this flag, and adding new test cases for these changes.

### Updates to `ActivityBuilder` logic:
* [`src/Query/ActivityBuilder.php`](diffhunk://#diff-0eb8b7f3ab7b5faefb4e93eac2ef66b91adf4c3eefae7bbdf5c8586c9eab1dfeL128-R128): Modified the `prepareEstateOrAddressParameters` method to accept a `create` flag, which determines whether the address parameter key is `addressid` or `addressids`. Updated calls to this method to pass the appropriate flag. [[1]](diffhunk://#diff-0eb8b7f3ab7b5faefb4e93eac2ef66b91adf4c3eefae7bbdf5c8586c9eab1dfeL128-R128) [[2]](diffhunk://#diff-0eb8b7f3ab7b5faefb4e93eac2ef66b91adf4c3eefae7bbdf5c8586c9eab1dfeL223-R223) [[3]](diffhunk://#diff-0eb8b7f3ab7b5faefb4e93eac2ef66b91adf4c3eefae7bbdf5c8586c9eab1dfeL237-R242)

### New test cases:
* [`tests/Query/ActivityBuilderTest.php`](diffhunk://#diff-159771086769eeffc712ab7c3a891fb759ab49e50e273fb8cf5cdff2b13698afR102-R113): Added a test to verify that the `addressIds` parameter is set correctly when calling the `create` method.
* [`tests/Query/ActivityBuilderTest.php`](diffhunk://#diff-159771086769eeffc712ab7c3a891fb759ab49e50e273fb8cf5cdff2b13698afR189-R207): Added a test to ensure that activities are created with the correct combination of `estateId` and `addressIds` parameters.