### PR TITLE
fix(security): update npm deps (brace-expansion, markdown-it)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "laravel-onoffice-adapter",
+  "name": "statamic-onoffice",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "statamic-onoffice",
       "devDependencies": {
         "vitepress": "^1.6.3",
         "vitepress-plugin-llms": "^1.3.2"
@@ -1682,9 +1683,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2232,9 +2233,9 @@
       "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Fix `brace-expansion` moderate vulnerability (GHSA-f886-m6hf-6m8v)
- Fix `markdown-it` moderate ReDoS vulnerability (GHSA-38c4-r59v-3vqw)

Note: `esbuild`/`vite` advisory (GHSA-67mh-4wv8-2f99) has no fix available upstream yet.

## Test plan
- [x] `npm audit` shows only esbuild/vite (no fix available)
- [ ] Verify build works correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>