### PR TITLE
fix: stop sending listoffset on task reads

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -369,6 +369,30 @@ class Builder implements BuilderInterface
     }
 
     /**
+     * Apply the list window (limit and, where supported, offset) to a read request.
+     *
+     * A resource whose endpoint rejects listoffset omits it and can therefore
+     * only read the first page; requesting a later page (a non-zero offset) is a
+     * hard error rather than a silent first-page result.
+     *
+     * @throws OnOfficeException
+     */
+    protected function applyListWindow(OnOfficeRequest $request, int $listLimit, int $offset): void
+    {
+        data_set($request->parameters, OnOfficeService::LISTLIMIT, $listLimit);
+
+        if ($this->supportsListOffset) {
+            data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
+
+            return;
+        }
+
+        throw_if($offset > 0, new OnOfficeException(
+            'This resource does not support offset pagination; only the first page can be read.'
+        ));
+    }
+
+    /**
      * @return Collection<int, array<string, mixed>>
      *
      * @throws OnOfficeException
@@ -379,10 +403,7 @@ class Builder implements BuilderInterface
          * @throws OnOfficeException
          * @throws Throwable
          */ function (int $pageSize, int $offset) use ($request) {
-            data_set($request->parameters, OnOfficeService::LISTLIMIT, $pageSize);
-            if ($this->supportsListOffset) {
-                data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
-            }
+            $this->applyListWindow($request, $pageSize, $offset);
 
             return $this->requestApi($request);
         }, pageSize: $this->pageSize, offset: $this->offset, limit: $this->limit, pageOverwrite: $this->getPageOverwrite());
@@ -411,10 +432,7 @@ class Builder implements BuilderInterface
          * @throws OnOfficeException
          * @throws Throwable
          */ function (int $pageSize, int $offset) use ($request) {
-            data_set($request->parameters, OnOfficeService::LISTLIMIT, $pageSize);
-            if ($this->supportsListOffset) {
-                data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
-            }
+            $this->applyListWindow($request, $pageSize, $offset);
 
             return $this->requestApi($request);
         }, $callback, pageSize: $this->pageSize, offset: $this->offset, limit: $this->limit, pageOverwrite: $this->getPageOverwrite());

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -82,6 +82,13 @@ class Builder implements BuilderInterface
     public array $customParameters = [];
 
     /**
+     * Whether the resource's read endpoint accepts a listoffset parameter.
+     * Most do; a few (e.g. the task endpoint) reject it outright, so their
+     * builders opt out and reads are bounded to a single listlimit page.
+     */
+    protected bool $supportsListOffset = true;
+
+    /**
      * The stub callables that will be used to fake the responses.
      *
      * @var Collection<int, OnOfficeResponse>
@@ -373,7 +380,9 @@ class Builder implements BuilderInterface
          * @throws Throwable
          */ function (int $pageSize, int $offset) use ($request) {
             data_set($request->parameters, OnOfficeService::LISTLIMIT, $pageSize);
-            data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
+            if ($this->supportsListOffset) {
+                data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
+            }
 
             return $this->requestApi($request);
         }, pageSize: $this->pageSize, offset: $this->offset, limit: $this->limit, pageOverwrite: $this->getPageOverwrite());
@@ -403,7 +412,9 @@ class Builder implements BuilderInterface
          * @throws Throwable
          */ function (int $pageSize, int $offset) use ($request) {
             data_set($request->parameters, OnOfficeService::LISTLIMIT, $pageSize);
-            data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
+            if ($this->supportsListOffset) {
+                data_set($request->parameters, OnOfficeService::LISTOFFSET, $offset);
+            }
 
             return $this->requestApi($request);
         }, $callback, pageSize: $this->pageSize, offset: $this->offset, limit: $this->limit, pageOverwrite: $this->getPageOverwrite());

--- a/src/Query/Concerns/Paginate.php
+++ b/src/Query/Concerns/Paginate.php
@@ -38,10 +38,7 @@ trait Paginate
     public function first(): ?array
     {
         $request = $this->buildReadRequest();
-        data_set($request->parameters, OnOfficeService::LISTLIMIT, $this->limit > 0 ? $this->limit : $this->pageSize);
-        if ($this->supportsListOffset) {
-            data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
-        }
+        $this->applyListWindow($request, $this->limit > 0 ? $this->limit : $this->pageSize, $this->offset);
 
         return $this->requestApi($request)->json('response.results.0.data.records.0');
     }
@@ -178,10 +175,7 @@ trait Paginate
     protected function getPageWithMeta(): PaginatedResponse
     {
         $request = $this->buildReadRequest();
-        data_set($request->parameters, OnOfficeService::LISTLIMIT, $this->pageSize);
-        if ($this->supportsListOffset) {
-            data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
-        }
+        $this->applyListWindow($request, $this->pageSize, $this->offset);
 
         $response = $this->requestApi($request);
 

--- a/src/Query/Concerns/Paginate.php
+++ b/src/Query/Concerns/Paginate.php
@@ -39,7 +39,9 @@ trait Paginate
     {
         $request = $this->buildReadRequest();
         data_set($request->parameters, OnOfficeService::LISTLIMIT, $this->limit > 0 ? $this->limit : $this->pageSize);
-        data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
+        if ($this->supportsListOffset) {
+            data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
+        }
 
         return $this->requestApi($request)->json('response.results.0.data.records.0');
     }
@@ -177,7 +179,9 @@ trait Paginate
     {
         $request = $this->buildReadRequest();
         data_set($request->parameters, OnOfficeService::LISTLIMIT, $this->pageSize);
-        data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
+        if ($this->supportsListOffset) {
+            data_set($request->parameters, OnOfficeService::LISTOFFSET, $this->offset);
+        }
 
         $response = $this->requestApi($request);
 

--- a/src/Query/TaskBuilder.php
+++ b/src/Query/TaskBuilder.php
@@ -31,6 +31,13 @@ class TaskBuilder extends Builder
     public ?int $relatedProjectId = null;
 
     /**
+     * The task endpoint rejects listoffset outright ("Invalid field in input
+     * data: listoffset"), so reads never send it and are bounded to a single
+     * listlimit page (max 500).
+     */
+    protected bool $supportsListOffset = false;
+
+    /**
      * Count matching tasks.
      *
      * Unlike other resources, the task endpoint's `meta.cntabsolute` equals the

--- a/tests/Query/TaskBuilderTest.php
+++ b/tests/Query/TaskBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Http;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Query\TaskBuilder;
 use Innobrain\OnOfficeAdapter\Repositories\TaskRepository;
 
@@ -297,5 +298,12 @@ describe('listoffset', function () {
             return array_key_exists('listlimit', $params)
                 && ! array_key_exists('listoffset', $params);
         });
+    });
+
+    it('throws when a later page is requested because the endpoint cannot offset', function () {
+        $builder = new TaskBuilder;
+
+        expect(fn () => $builder->setRepository(new TaskRepository)->paginate(perPage: 10, page: 3))
+            ->toThrow(OnOfficeException::class, 'does not support offset pagination');
     });
 });

--- a/tests/Query/TaskBuilderTest.php
+++ b/tests/Query/TaskBuilderTest.php
@@ -240,3 +240,62 @@ describe('count', function () {
         expect($builder->setRepository(new TaskRepository)->count())->toBe(13);
     });
 });
+
+describe('listoffset', function () {
+    beforeEach(function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::response([
+                'status' => ['code' => 200],
+                'response' => [
+                    'results' => [
+                        [
+                            'data' => [
+                                'meta' => ['cntabsolute' => 1],
+                                'records' => [
+                                    ['id' => 1, 'type' => 'task', 'elements' => []],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+    });
+
+    it('omits listoffset from get() because the task endpoint rejects it', function () {
+        $builder = new TaskBuilder;
+        $builder->setRepository(new TaskRepository)->get();
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $params = data_get(json_decode($request->body(), true), 'request.actions.0.parameters', []);
+
+            return array_key_exists('listlimit', $params)
+                && ! array_key_exists('listoffset', $params);
+        });
+    });
+
+    it('omits listoffset from paginate() but keeps listlimit', function () {
+        $builder = new TaskBuilder;
+        $builder->setRepository(new TaskRepository)->paginate(perPage: 26, page: 1);
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $params = data_get(json_decode($request->body(), true), 'request.actions.0.parameters', []);
+
+            return data_get($params, 'listlimit') === 26
+                && ! array_key_exists('listoffset', $params);
+        });
+    });
+
+    it('omits listoffset from first()', function () {
+        $builder = new TaskBuilder;
+        $builder->setRepository(new TaskRepository)->first();
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $params = data_get(json_decode($request->body(), true), 'request.actions.0.parameters', []);
+
+            return array_key_exists('listlimit', $params)
+                && ! array_key_exists('listoffset', $params);
+        });
+    });
+});


### PR DESCRIPTION
The task read endpoint rejects listoffset outright ("Invalid field in input data: listoffset"), but TaskBuilder inherited the generic read and pagination paths, which always send it — so get(), paginate(), first() and each() failed against the real API.

Add a $supportsListOffset flag on Builder (default true) and guard every listoffset write site behind it; TaskBuilder opts out. Task reads are therefore bounded to a single listlimit page, which is all the endpoint supports anyway.