### PR TITLE
refactor: extract shared FileBuilder base to remove duplication

### DIFF
--- a/src/Query/AddressFileBuilder.php
+++ b/src/Query/AddressFileBuilder.php
@@ -4,18 +4,9 @@ declare(strict_types=1);
 
 namespace Innobrain\OnOfficeAdapter\Query;
 
-use Illuminate\Support\Collection;
-use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeError;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
-use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
-use Throwable;
 
-class AddressFileBuilder extends Builder
+class AddressFileBuilder extends FileBuilder
 {
     public function __construct(
         public int $addressId,
@@ -23,130 +14,23 @@ class AddressFileBuilder extends Builder
         parent::__construct();
     }
 
-    /**
-     * @throws OnOfficeException
-     */
-    public function get(): Collection
+    protected function resourceId(): OnOfficeResourceId
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Address,
-            parameters: [
-                'addressid' => $this->addressId,
-                OnOfficeService::LISTLIMIT => $this->limit,
-                OnOfficeService::LISTOFFSET => $this->offset,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestAll($request);
+        return OnOfficeResourceId::Address;
     }
 
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function first(): ?array
+    protected function parentIdParameter(): string
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Address,
-            parameters: [
-                'addressid' => $this->addressId,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return 'addressid';
     }
 
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function find(int $id): ?array
+    protected function relationType(): string
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Address,
-            parameters: [
-                'addressid' => $this->addressId,
-                'fileid' => $id,
-                ...$this->customParameters,
-            ],
-        );
-
-        $response = $this->requestApi($request);
-
-        $result = $response->json(OnOfficeResponsePath::FIRST_RECORD);
-
-        throw_unless($result,
-            OnOfficeException::class,
-            OnOfficeError::File_Not_Found->toString(),
-            OnOfficeError::File_Not_Found->value, // @phpstan-ignore argument.type
-            isResponseError: true); // @phpstan-ignore argument.type
-
-        return $result;
+        return 'address';
     }
 
-    /**
-     * @throws OnOfficeException
-     */
-    public function each(callable $callback): void
+    protected function parentId(): int
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Address,
-            parameters: [
-                'addressid' => $this->addressId,
-                ...$this->customParameters,
-            ],
-        );
-
-        $this->requestAllChunked($request, $callback);
-    }
-
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function modify(int $id): bool
-    {
-        $parameters = array_replace($this->modifies, [
-            'fileId' => $id,
-            'parentid' => $this->addressId,
-            'relationtype' => 'address',
-        ]);
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Modify,
-            OnOfficeResourceType::FileRelation,
-            parameters: $parameters,
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
-    }
-
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function delete(int $id): bool
-    {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Delete,
-            OnOfficeResourceType::FileRelation,
-            parameters: [
-                'fileId' => $id,
-                'parentid' => $this->addressId,
-                'relationtype' => 'address',
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
+        return $this->addressId;
     }
 }

--- a/src/Query/EstateFileBuilder.php
+++ b/src/Query/EstateFileBuilder.php
@@ -4,18 +4,9 @@ declare(strict_types=1);
 
 namespace Innobrain\OnOfficeAdapter\Query;
 
-use Illuminate\Support\Collection;
-use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeError;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
-use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
-use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
-use Throwable;
 
-class EstateFileBuilder extends Builder
+class EstateFileBuilder extends FileBuilder
 {
     public function __construct(
         public int $estateId,
@@ -23,130 +14,23 @@ class EstateFileBuilder extends Builder
         parent::__construct();
     }
 
-    /**
-     * @throws OnOfficeException
-     */
-    public function get(): Collection
+    protected function resourceId(): OnOfficeResourceId
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Estate,
-            parameters: [
-                'estateid' => $this->estateId,
-                OnOfficeService::LISTLIMIT => $this->limit,
-                OnOfficeService::LISTOFFSET => $this->offset,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestAll($request);
+        return OnOfficeResourceId::Estate;
     }
 
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function first(): ?array
+    protected function parentIdParameter(): string
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Estate,
-            parameters: [
-                'estateid' => $this->estateId,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return 'estateid';
     }
 
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function find(int $id): ?array
+    protected function relationType(): string
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Estate,
-            parameters: [
-                'estateid' => $this->estateId,
-                'fileid' => $id,
-                ...$this->customParameters,
-            ],
-        );
-
-        $response = $this->requestApi($request);
-
-        $result = $response->json(OnOfficeResponsePath::FIRST_RECORD);
-
-        throw_unless($result,
-            OnOfficeException::class,
-            OnOfficeError::File_Not_Found->toString(),
-            OnOfficeError::File_Not_Found->value, // @phpstan-ignore argument.type
-            isResponseError: true); // @phpstan-ignore argument.type
-
-        return $result;
+        return 'estate';
     }
 
-    /**
-     * @throws OnOfficeException
-     */
-    public function each(callable $callback): void
+    protected function parentId(): int
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::File,
-            OnOfficeResourceId::Estate,
-            parameters: [
-                'estateid' => $this->estateId,
-                ...$this->customParameters,
-            ],
-        );
-
-        $this->requestAllChunked($request, $callback);
-    }
-
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function modify(int $id): bool
-    {
-        $parameters = array_replace($this->modifies, [
-            'fileId' => $id,
-            'parentid' => $this->estateId,
-            'relationtype' => 'estate',
-        ]);
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Modify,
-            OnOfficeResourceType::FileRelation,
-            parameters: $parameters,
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
-    }
-
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function delete(int $id): bool
-    {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Delete,
-            OnOfficeResourceType::FileRelation,
-            parameters: [
-                'fileId' => $id,
-                'parentid' => $this->estateId,
-                'relationtype' => 'estate',
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
+        return $this->estateId;
     }
 }

--- a/src/Query/FileBuilder.php
+++ b/src/Query/FileBuilder.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Innobrain\OnOfficeAdapter\Query;
+
+use Illuminate\Support\Collection;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeError;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
+use Throwable;
+
+abstract class FileBuilder extends Builder
+{
+    /**
+     * The onOffice resource the files are attached to (e.g. Estate, Address).
+     */
+    abstract protected function resourceId(): OnOfficeResourceId;
+
+    /**
+     * The request parameter name carrying the parent id (e.g. "estateid").
+     */
+    abstract protected function parentIdParameter(): string;
+
+    /**
+     * The relation type used when modifying or deleting file relations (e.g. "estate").
+     */
+    abstract protected function relationType(): string;
+
+    /**
+     * The id of the parent record the files belong to.
+     */
+    abstract protected function parentId(): int;
+
+    /**
+     * @throws OnOfficeException
+     */
+    public function get(): Collection
+    {
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::File,
+            $this->resourceId(),
+            parameters: [
+                $this->parentIdParameter() => $this->parentId(),
+                OnOfficeService::LISTLIMIT => $this->limit,
+                OnOfficeService::LISTOFFSET => $this->offset,
+                ...$this->customParameters,
+            ],
+        );
+
+        return $this->requestAll($request);
+    }
+
+    /**
+     * @throws Throwable<OnOfficeException>
+     */
+    public function first(): ?array
+    {
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::File,
+            $this->resourceId(),
+            parameters: [
+                $this->parentIdParameter() => $this->parentId(),
+                ...$this->customParameters,
+            ],
+        );
+
+        return $this->requestApi($request)
+            ->json(OnOfficeResponsePath::FIRST_RECORD);
+    }
+
+    /**
+     * @throws Throwable<OnOfficeException>
+     */
+    public function find(int $id): ?array
+    {
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::File,
+            $this->resourceId(),
+            parameters: [
+                $this->parentIdParameter() => $this->parentId(),
+                'fileid' => $id,
+                ...$this->customParameters,
+            ],
+        );
+
+        $response = $this->requestApi($request);
+
+        $result = $response->json(OnOfficeResponsePath::FIRST_RECORD);
+
+        throw_unless($result,
+            OnOfficeException::class,
+            OnOfficeError::File_Not_Found->toString(),
+            OnOfficeError::File_Not_Found->value, // @phpstan-ignore argument.type
+            isResponseError: true); // @phpstan-ignore argument.type
+
+        return $result;
+    }
+
+    /**
+     * @throws OnOfficeException
+     */
+    public function each(callable $callback): void
+    {
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::File,
+            $this->resourceId(),
+            parameters: [
+                $this->parentIdParameter() => $this->parentId(),
+                ...$this->customParameters,
+            ],
+        );
+
+        $this->requestAllChunked($request, $callback);
+    }
+
+    /**
+     * @throws Throwable<OnOfficeException>
+     */
+    public function modify(int $id): bool
+    {
+        $parameters = array_replace($this->modifies, [
+            'fileId' => $id,
+            'parentid' => $this->parentId(),
+            'relationtype' => $this->relationType(),
+        ]);
+
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Modify,
+            OnOfficeResourceType::FileRelation,
+            parameters: $parameters,
+        );
+
+        return $this->requestApi($request)
+            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
+    }
+
+    /**
+     * @throws Throwable<OnOfficeException>
+     */
+    public function delete(int $id): bool
+    {
+        $request = new OnOfficeRequest(
+            OnOfficeAction::Delete,
+            OnOfficeResourceType::FileRelation,
+            parameters: [
+                'fileId' => $id,
+                'parentid' => $this->parentId(),
+                'relationtype' => $this->relationType(),
+                ...$this->customParameters,
+            ],
+        );
+
+        return $this->requestApi($request)
+            ->json(OnOfficeResponsePath::FIRST_RECORD_ELEMENTS_SUCCESS) === 'success';
+    }
+}


### PR DESCRIPTION
## The deviation

`AddressFileBuilder` and `EstateFileBuilder` were **~95% identical** — the same six methods (`get`, `first`, `find`, `each`, `modify`, `delete`) copy-pasted across two 152-line files, differing only in four tokens: the `OnOfficeResourceId` enum case, the parent-id parameter name (`addressid`/`estateid`), the relation type (`address`/`estate`), and the id property.

This is the kind of duplication Laravel's design philosophy works hardest to eliminate (DRY, "don't repeat yourself, build expressive abstractions"). It also doubles the maintenance cost: every bug fix or new file method had to be applied — and kept in sync — in two places.

## The fix

Introduce an abstract `FileBuilder` that holds all the shared request-building logic, with four small template methods supplied by each concrete builder:

```php
abstract protected function resourceId(): OnOfficeResourceId;
abstract protected function parentIdParameter(): string;
abstract protected function relationType(): string;
abstract protected function parentId(): int;
```

Each concrete builder shrinks to a constructor plus those four one-liners.

## Backward compatibility

Fully preserved. The public constructors and the public `$addressId` / `$estateId` properties are unchanged, so existing callers (`AddressRepository::files($id)`, `EstateRepository::files($id)`) behave exactly as before. The generated `OnOfficeRequest` payloads are byte-for-byte identical.

`AppointmentFileBuilder` is intentionally left untouched — it only implements `get()`, uses a raw string resource id and the `Non*` traits, so it isn't part of this duplication.

## Verification

- **Pest:** full suite green — 625 tests, 838 assertions
- **PHPStan:** level 8, no errors
- **Pint:** passes

Net change: **+18 / −250 lines** across the two concrete builders, ~130 lines of duplicated logic removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WT6cTQjzozR3vjSsswkNjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT6cTQjzozR3vjSsswkNjR)_