### PR TITLE
refactor: route builder parameter keys through OnOfficeParameterConst

### DIFF
--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -93,7 +93,7 @@ class ActivityBuilder extends Builder
      */
     public function estate(): static
     {
-        $this->estateOrAddress = 'estateid';
+        $this->estateOrAddress = OnOfficeService::ESTATEID;
 
         return $this;
     }
@@ -103,7 +103,7 @@ class ActivityBuilder extends Builder
      */
     public function address(): static
     {
-        $this->estateOrAddress = 'addressid';
+        $this->estateOrAddress = OnOfficeService::ADDRESSID;
 
         return $this;
     }
@@ -161,13 +161,13 @@ class ActivityBuilder extends Builder
         }
 
         if (! is_null($this->estateId)) {
-            $parameters['estateid'] = $this->estateId;
+            $parameters[OnOfficeService::ESTATEID] = $this->estateId;
         }
 
         if ($this->addressIds !== []) {
             $key = match ($create) {
-                true => 'addressids',
-                false => 'addressid',
+                true => OnOfficeService::ADDRESSIDS,
+                false => OnOfficeService::ADDRESSID,
             };
 
             $parameters[$key] = $this->addressIds;

--- a/src/Query/AddressFileBuilder.php
+++ b/src/Query/AddressFileBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Innobrain\OnOfficeAdapter\Query;
 
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 
 class AddressFileBuilder extends FileBuilder
 {
@@ -21,7 +22,7 @@ class AddressFileBuilder extends FileBuilder
 
     protected function parentIdParameter(): string
     {
-        return 'addressid';
+        return OnOfficeService::ADDRESSID;
     }
 
     protected function relationType(): string

--- a/src/Query/AppointmentFileBuilder.php
+++ b/src/Query/AppointmentFileBuilder.php
@@ -36,7 +36,7 @@ class AppointmentFileBuilder extends Builder
             OnOfficeResourceType::File,
             'appointment',
             parameters: [
-                'appointmentid' => $this->appointmentId,
+                OnOfficeService::APPOINTMENTID => $this->appointmentId,
                 OnOfficeService::LISTLIMIT => $this->limit,
                 OnOfficeService::LISTOFFSET => $this->offset,
                 ...$this->customParameters,

--- a/src/Query/EstateFileBuilder.php
+++ b/src/Query/EstateFileBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Innobrain\OnOfficeAdapter\Query;
 
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 
 class EstateFileBuilder extends FileBuilder
 {
@@ -21,7 +22,7 @@ class EstateFileBuilder extends FileBuilder
 
     protected function parentIdParameter(): string
     {
-        return 'estateid';
+        return OnOfficeService::ESTATEID;
     }
 
     protected function relationType(): string

--- a/src/Query/EstatePictureBuilder.php
+++ b/src/Query/EstatePictureBuilder.php
@@ -11,6 +11,7 @@ use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceId;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 
 class EstatePictureBuilder extends Builder
 {
@@ -64,7 +65,7 @@ class EstatePictureBuilder extends Builder
             OnOfficeResourceType::EstatePictures,
             OnOfficeResourceId::None,
             parameters: [
-                'estateids' => $this->estateIds,
+                OnOfficeService::ESTATEIDS => $this->estateIds,
                 'categories' => $this->categories,
                 ...$this->customParameters,
             ],
@@ -87,7 +88,7 @@ class EstatePictureBuilder extends Builder
             OnOfficeResourceType::EstatePictures,
             OnOfficeResourceId::None,
             parameters: [
-                'estateids' => $this->estateIds,
+                OnOfficeService::ESTATEIDS => $this->estateIds,
                 'categories' => $this->categories,
                 ...$this->customParameters,
             ],

--- a/src/Query/FileBuilder.php
+++ b/src/Query/FileBuilder.php
@@ -87,7 +87,7 @@ abstract class FileBuilder extends Builder
             $this->resourceId(),
             parameters: [
                 $this->parentIdParameter() => $this->parentId(),
-                'fileid' => $id,
+                OnOfficeService::FILEID => $id,
                 ...$this->customParameters,
             ],
         );
@@ -130,8 +130,8 @@ abstract class FileBuilder extends Builder
     {
         $parameters = array_replace($this->modifies, [
             'fileId' => $id,
-            'parentid' => $this->parentId(),
-            'relationtype' => $this->relationType(),
+            OnOfficeService::PARENTID => $this->parentId(),
+            OnOfficeService::RELATIONTYPE => $this->relationType(),
         ]);
 
         $request = new OnOfficeRequest(
@@ -154,8 +154,8 @@ abstract class FileBuilder extends Builder
             OnOfficeResourceType::FileRelation,
             parameters: [
                 'fileId' => $id,
-                'parentid' => $this->parentId(),
-                'relationtype' => $this->relationType(),
+                OnOfficeService::PARENTID => $this->parentId(),
+                OnOfficeService::RELATIONTYPE => $this->relationType(),
                 ...$this->customParameters,
             ],
         );

--- a/src/Query/MacroBuilder.php
+++ b/src/Query/MacroBuilder.php
@@ -9,6 +9,7 @@ use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 
 class MacroBuilder extends Builder
 {
@@ -49,7 +50,7 @@ class MacroBuilder extends Builder
      */
     public function estateIds(int|array $ids): static
     {
-        return $this->parameter('estateids', Arr::wrap($ids));
+        return $this->parameter(OnOfficeService::ESTATEIDS, Arr::wrap($ids));
     }
 
     /**
@@ -59,7 +60,7 @@ class MacroBuilder extends Builder
      */
     public function addressIds(int|array $ids): static
     {
-        return $this->parameter('addressids', Arr::wrap($ids));
+        return $this->parameter(OnOfficeService::ADDRESSIDS, Arr::wrap($ids));
     }
 
     /**

--- a/src/Query/SearchCriteriaBuilder.php
+++ b/src/Query/SearchCriteriaBuilder.php
@@ -85,7 +85,7 @@ class SearchCriteriaBuilder extends Builder
             OnOfficeAction::Create,
             OnOfficeResourceType::SearchCriteria,
             parameters: [
-                'addressid' => $this->addressId,
+                OnOfficeService::ADDRESSID => $this->addressId,
                 OnOfficeService::DATA => $data,
             ],
         );

--- a/src/Services/OnOfficeParameterConst.php
+++ b/src/Services/OnOfficeParameterConst.php
@@ -35,6 +35,18 @@ trait OnOfficeParameterConst
 
     public const RECORDID = 'recordId';
 
+    public const ESTATEID = 'estateid';
+
+    public const ESTATEIDS = 'estateids';
+
+    public const ADDRESSID = 'addressid';
+
+    public const ADDRESSIDS = 'addressids';
+
+    public const APPOINTMENTID = 'appointmentid';
+
+    public const FILEID = 'fileid';
+
     public const PARAMETERCACHEID = 'parameterCacheId';
 
     public const EXTENDEDCLAIM = 'extendedclaim';


### PR DESCRIPTION
## What & why

The package already establishes a clear convention for onOffice request parameter names: they live as constants in the `OnOfficeParameterConst` trait and are referenced via `OnOfficeService::*` (e.g. `OnOfficeService::LISTLIMIT`, `OnOfficeService::PARENTID`). A recent change (#59) did the same thing for response paths via `OnOfficeResponsePath`.

Several query builders **bypassed that convention**, hardcoding entity-id and relation parameter keys as magic strings scattered across six files — sometimes literally next to a constant reference:

```php
parameters: [
    'estateid' => $this->estateId,            // ❌ magic string
    OnOfficeService::LISTLIMIT => $this->limit, // ✅ constant, same array
    OnOfficeService::LISTOFFSET => $this->offset,
],
```

Deviating from a convention the codebase itself has already established (and is actively extending) is the most glaring kind of inconsistency: it's pure DRY debt, and any change to a parameter name means hunting through multiple files instead of one source of truth.

## Change

- Add the missing `ESTATEID`, `ESTATEIDS`, `ADDRESSID`, `ADDRESSIDS`, `FILEID` constants to `OnOfficeParameterConst`.
- Reference all entity-id and relation parameter **keys** through the trait across `EstateFileBuilder`, `AddressFileBuilder`, `ActivityBuilder`, `MacroBuilder`, `EstatePictureBuilder`, and `SearchCriteriaBuilder`.

Every wire value is preserved exactly, so the produced API payloads are byte-for-byte identical. This is a pure, non-behavioral refactor.

## Verification

- ✅ Full test suite: **625 passed (838 assertions)** — the builder tests assert exact parameter keys (`'estateid'`, `'addressids'`, …), confirming the wire values are unchanged.
- ✅ `vendor/bin/pint` — passed.

## Flagged for follow-up (intentionally not touched here)

The File-relation `modify()` / `delete()` calls send `'fileId'` (camelCase) while the File `get()` / `find()` calls send `'fileid'` (lowercase). That casing discrepancy is left as a literal on purpose — normalizing it would change API behavior and it isn't covered by tests or the local API docs (Relations are an uncovered module). It deserves a separate, deliberate fix; you'll see it stand out as the lone literal next to the new constants in `EstateFileBuilder`/`AddressFileBuilder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyUFAW31VosZmE3Tyk94xu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QyUFAW31VosZmE3Tyk94xu)_