### PR TITLE
refactor: extract duplicated find() into shared Builder::requestFind()

### DIFF
--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -52,18 +52,7 @@ class ActivityBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::Activity,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ]
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Get, OnOfficeResourceType::Activity, $id);
     }
 
     /**

--- a/src/Query/AddressBuilder.php
+++ b/src/Query/AddressBuilder.php
@@ -46,18 +46,7 @@ class AddressBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Address,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ]
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Address, $id);
     }
 
     /**

--- a/src/Query/AppointmentBuilder.php
+++ b/src/Query/AppointmentBuilder.php
@@ -107,18 +107,7 @@ class AppointmentBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::AppointmentList,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ]
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Get, OnOfficeResourceType::AppointmentList, $id);
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -679,6 +679,29 @@ class Builder implements BuilderInterface
     }
 
     /**
+     * Build and send a request to read a single record by its id.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws OnOfficeException
+     */
+    protected function requestFind(OnOfficeAction $action, OnOfficeResourceType $resourceType, int $id): ?array
+    {
+        $request = new OnOfficeRequest(
+            $action,
+            $resourceType,
+            $id,
+            parameters: [
+                OnOfficeService::DATA => $this->columns,
+                ...$this->customParameters,
+            ],
+        );
+
+        return $this->requestApi($request)
+            ->json(OnOfficeResponsePath::FIRST_RECORD);
+    }
+
+    /**
      * @return array<string, mixed>|null
      *
      * @throws OnOfficeException

--- a/src/Query/EstateBuilder.php
+++ b/src/Query/EstateBuilder.php
@@ -40,18 +40,7 @@ class EstateBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Estate,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Estate, $id);
     }
 
     /**

--- a/src/Query/ImprintBuilder.php
+++ b/src/Query/ImprintBuilder.php
@@ -60,17 +60,6 @@ class ImprintBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Impressum,
-            resourceId: $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ]
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Impressum, $id);
     }
 }

--- a/src/Query/TaskBuilder.php
+++ b/src/Query/TaskBuilder.php
@@ -80,18 +80,7 @@ class TaskBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Task,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ],
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Task, $id);
     }
 
     /**

--- a/src/Query/UserBuilder.php
+++ b/src/Query/UserBuilder.php
@@ -9,7 +9,6 @@ use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Query\Concerns\Paginate;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
 use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 use Throwable;
 
@@ -36,17 +35,6 @@ class UserBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::User,
-            $id,
-            parameters: [
-                OnOfficeService::DATA => $this->columns,
-                ...$this->customParameters,
-            ]
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::User, $id);
     }
 }


### PR DESCRIPTION
## The deviation

The single-record read in `find()` was copy-pasted **verbatim** across seven query builders — `EstateBuilder`, `AddressBuilder`, `TaskBuilder`, `UserBuilder`, `ImprintBuilder`, `ActivityBuilder`, and `AppointmentBuilder`. Every copy rebuilt the same `OnOfficeRequest` (`DATA => $this->columns` + `...$this->customParameters`) and read the same `OnOfficeResponsePath::FIRST_RECORD`, differing only in the `OnOfficeAction` and `OnOfficeResourceType`.

This is the most glaring departure from the framework's DRY/template-method philosophy in the package: ~14 lines of identical request-building logic duplicated 7×, so any change to how a record is fetched (a new parameter, a response-path tweak, error handling) has to be made in seven places and can silently drift between them. It's also exactly the direction the repo has been moving recently (`#61` extract shared FileBuilder base, `#59` extract response-path constants).

## The fix

Hoist the shared body into a single protected template helper on the base `Builder`:

```php
protected function requestFind(OnOfficeAction $action, OnOfficeResourceType $resourceType, int $id): ?array
{
    $request = new OnOfficeRequest($action, $resourceType, $id, parameters: [
        OnOfficeService::DATA => $this->columns,
        ...$this->customParameters,
    ]);

    return $this->requestApi($request)->json(OnOfficeResponsePath::FIRST_RECORD);
}
```

Each builder now delegates, passing only what actually varies:

```php
public function find(int $id): ?array
{
    return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Estate, $id);
}
```

**Scope is deliberately narrow and behaviour-preserving.** Only `find()` was byte-identical across builders. `create()` and `modify()` are intentionally left untouched because their per-entity parameter shapes genuinely differ (e.g. `TaskBuilder` adds related IDs via `array_filter`, `AppointmentBuilder::modify` checks `FIRST_RECORD_ELEMENTS`). Builders with bespoke `find()` logic (`FileBuilder`, `LogBuilder`, `LinkBuilder`, `LastSeenBuilder`, `SearchCriteriaBuilder`) are also untouched.

## Result

- Net **−55 lines** (30 added, 85 removed across 8 files).
- All **625** tests pass (`vendor/bin/pest`).
- PHPStan level 8 clean (`composer analyse`).
- No public API or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYZWsibpan8B6ey6AraZKK)_