### PR TITLE
refactor: route LogBuilder through the shared Paginate concern

### DIFF
--- a/src/Query/LogBuilder.php
+++ b/src/Query/LogBuilder.php
@@ -4,34 +4,30 @@ declare(strict_types=1);
 
 namespace Innobrain\OnOfficeAdapter\Query;
 
-use Illuminate\Support\Collection;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
+use Innobrain\OnOfficeAdapter\Query\Concerns\Paginate;
 use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 use Throwable;
 
 class LogBuilder extends Builder
 {
+    use Paginate;
+
     public string $module = '';
 
     public string $action = '';
 
     public int $userId = -1;
 
-    /**
-     * @throws OnOfficeException
-     */
-    public function get(): Collection
+    protected function buildReadRequest(): OnOfficeRequest
     {
         $parameters = [
             OnOfficeService::MODULE => $this->module,
             OnOfficeService::ACTION => $this->action,
             OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
             ...$this->customParameters,
         ];
 
@@ -39,42 +35,11 @@ class LogBuilder extends Builder
             $parameters['user'] = $this->userId;
         }
 
-        $request = new OnOfficeRequest(
+        return new OnOfficeRequest(
             OnOfficeAction::Read,
             OnOfficeResourceType::Log,
             parameters: $parameters,
         );
-
-        return $this->requestAll($request);
-    }
-
-    /**
-     * @throws OnOfficeException
-     * @throws Throwable
-     */
-    public function first(): ?array
-    {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Log,
-            parameters: $parameters,
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
     }
 
     /**
@@ -82,73 +47,7 @@ class LogBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Log,
-            $id,
-            parameters: $this->customParameters,
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
-    }
-
-    /**
-     * @throws OnOfficeException
-     */
-    public function each(callable $callback): void
-    {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Log,
-            parameters: $parameters,
-        );
-
-        $this->requestAllChunked($request, $callback);
-    }
-
-    /**
-     * Returns the number of records that match the query. This number is from the API
-     * and might be lower than the actual number of records when queried with get().
-     *
-     * @throws Throwable<OnOfficeException>
-     */
-    public function count(): int
-    {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Read,
-            OnOfficeResourceType::Log,
-            parameters: $parameters
-        );
-
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::META_COUNT_ABSOLUTE, 0);
+        return $this->requestFind(OnOfficeAction::Read, OnOfficeResourceType::Log, $id);
     }
 
     public function withModule(string $module): static

--- a/tests/Repositories/LogRepositoryTest.php
+++ b/tests/Repositories/LogRepositoryTest.php
@@ -26,6 +26,90 @@ describe('fake responses', function () {
 
         LogRepository::assertSentCount(1);
     });
+
+    test('first', function () {
+        LogRepository::fake(LogRepository::response([
+            LogRepository::page(recordFactories: [
+                LogFactory::make()->id(7),
+                LogFactory::make()->id(8),
+            ]),
+        ]));
+
+        $record = LogRepository::query()->first();
+
+        expect($record['id'])->toBe(7);
+
+        LogRepository::assertSentCount(1);
+    });
+
+    test('each', function () {
+        LogRepository::fake(LogRepository::response([
+            LogRepository::page(recordFactories: [
+                LogFactory::make()->id(1),
+                LogFactory::make()->id(2),
+            ]),
+        ]));
+
+        $ids = [];
+        LogRepository::query()->each(function (array $records) use (&$ids) {
+            foreach ($records as $record) {
+                $ids[] = $record['id'];
+            }
+        });
+
+        expect($ids)->toBe([1, 2]);
+
+        LogRepository::assertSentCount(1);
+    });
+
+    test('find', function () {
+        LogRepository::fake(LogRepository::response([
+            LogRepository::page(recordFactories: [
+                LogFactory::make()->id(13),
+            ]),
+        ]));
+
+        $record = LogRepository::query()->find(13);
+
+        expect($record['id'])->toBe(13);
+
+        LogRepository::assertSentCount(1);
+    });
+
+    test('read request carries module, action, user and filters', function () {
+        LogRepository::fake(LogRepository::response([
+            LogRepository::page(recordFactories: [
+                LogFactory::make()->id(1),
+            ]),
+        ]));
+
+        LogRepository::query()
+            ->withModule('estate')
+            ->withAction('edit')
+            ->withUserId(42)
+            ->where('actionId', 'create')
+            ->get();
+
+        LogRepository::assertSentCount(1);
+        LogRepository::assertSent(fn (OnOfficeRequest $request): bool => $request->actionId === OnOfficeAction::Read
+            && $request->resourceType === OnOfficeResourceType::Log
+            && $request->parameters['module'] === 'estate'
+            && $request->parameters['action'] === 'edit'
+            && $request->parameters['user'] === 42
+            && array_key_exists('actionId', $request->parameters['filter']));
+    });
+
+    test('read request omits user when no user id is set', function () {
+        LogRepository::fake(LogRepository::response([
+            LogRepository::page(recordFactories: [
+                LogFactory::make()->id(1),
+            ]),
+        ]));
+
+        LogRepository::query()->get();
+
+        LogRepository::assertSent(fn (OnOfficeRequest $request): bool => ! array_key_exists('user', $request->parameters));
+    });
 });
 
 describe('real responses', function () {


### PR DESCRIPTION
## What & why

`LogBuilder` was the **single most glaring deviation** from the package's own conventions: it was the only query builder that ignored the shared `Paginate` concern and hand-rolled `get()`, `first()`, `each()` and `count()` — copy-pasting an **identical ~13-line parameter block four times**.

Every other builder (`Estate`, `Address`, `Task`, `Activity`, `User`, `LastSeen`, `Appointment`, …) defines a single `buildReadRequest()` and inherits the terminal methods from `Query/Concerns/Paginate`. This is exactly the DRY/extract-shared-helper direction recent PRs in this repo have been pushing (#63 `Builder::requestFind()`, #61 shared `FileBuilder`, #59/#62 shared constants). `LogBuilder` was simply missed.

## Changes

- `LogBuilder` now `use`s the `Paginate` trait and implements one `buildReadRequest()`.
- The four duplicated parameter blocks collapse into that single method.
- `find()` now routes through the shared `Builder::requestFind()` helper (matching `TaskBuilder`).
- Dropped the redundant `listlimit` / `listoffset` parameters from the builder body — `requestAll()` / the `Paginate` terminal methods already apply the list window via `applyListWindow()`, so they were dead or overwritten values.

Net **−107 / +90 lines** with no behavioural change for `get()` / `count()`.

## Tests

The builder previously only had `get()` / `count()` coverage. Added tests for `first()`, `each()`, `find()`, and parameter parity (module/action/user/filter carried through; `user` omitted when unset).

- `vendor/bin/pest` → **632 passed** (up from 627), 851 assertions
- `vendor/bin/pint` → passed

> Note: `composer analyse` could not run cleanly in the sandbox due to a pre-existing larastan/phpstan config-key incompatibility in a fresh `composer install` (it errors on `phpstan.neon.dist` keys on the untouched `main` too, not on this change). The refactor mirrors `TaskBuilder` one-for-one, which is already PHPStan-level-8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZwGvUoC1LSVWoUdabiKM8)_