### PR TITLE
refactor: route TaskBuilder relation keys through OnOfficeParameterConst

### DIFF
--- a/src/Query/TaskBuilder.php
+++ b/src/Query/TaskBuilder.php
@@ -67,9 +67,7 @@ class TaskBuilder extends Builder
             parameters: array_filter([
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                'relatedAddressId' => $this->relatedAddressId,
-                'relatedEstateId' => $this->relatedEstateId,
-                'relatedProjectIds' => $this->relatedProjectId,
+                ...$this->relatedParameters(),
                 ...$this->customParameters,
             ], fn ($v) => ! is_null($v)),
         );
@@ -96,9 +94,7 @@ class TaskBuilder extends Builder
             OnOfficeResourceType::Task,
             parameters: array_filter([
                 OnOfficeService::DATA => $data,
-                'relatedAddressId' => $this->relatedAddressId,
-                'relatedEstateId' => $this->relatedEstateId,
-                'relatedProjectIds' => $this->relatedProjectId,
+                ...$this->relatedParameters(),
                 ...$this->customParameters,
             ], fn ($v) => ! is_null($v)),
         );
@@ -118,9 +114,7 @@ class TaskBuilder extends Builder
             $id,
             parameters: array_filter([
                 OnOfficeService::DATA => $this->modifies,
-                'relatedAddressId' => $this->relatedAddressId,
-                'relatedEstateId' => $this->relatedEstateId,
-                'relatedProjectIds' => $this->relatedProjectId,
+                ...$this->relatedParameters(),
                 ...$this->customParameters,
             ], fn ($v) => ! is_null($v)),
         );
@@ -128,6 +122,21 @@ class TaskBuilder extends Builder
         $this->requestApi($request);
 
         return true;
+    }
+
+    /**
+     * The relation parameters shared by the task read, create and modify
+     * requests. Null entries are stripped by the caller's array_filter.
+     *
+     * @return array<string, int|null>
+     */
+    private function relatedParameters(): array
+    {
+        return [
+            OnOfficeService::RELATEDADDRESSID => $this->relatedAddressId,
+            OnOfficeService::RELATEDESTATEID => $this->relatedEstateId,
+            OnOfficeService::RELATEDPROJECTIDS => $this->relatedProjectId,
+        ];
     }
 
     public function relatedAddress(int $id): static

--- a/src/Services/OnOfficeParameterConst.php
+++ b/src/Services/OnOfficeParameterConst.php
@@ -45,6 +45,12 @@ trait OnOfficeParameterConst
 
     public const APPOINTMENTID = 'appointmentid';
 
+    public const RELATEDADDRESSID = 'relatedAddressId';
+
+    public const RELATEDESTATEID = 'relatedEstateId';
+
+    public const RELATEDPROJECTIDS = 'relatedProjectIds';
+
     public const FILEID = 'fileid';
 
     public const PARAMETERCACHEID = 'parameterCacheId';


### PR DESCRIPTION
## What

`TaskBuilder` hardcoded the onOffice relation parameter keys (`relatedAddressId`, `relatedEstateId`, `relatedProjectIds`) as magic strings and repeated the identical relation-parameter block **verbatim across three methods** — `buildReadRequest()`, `create()`, and `modify()`.

This PR:
- Adds the missing `RELATEDADDRESSID` / `RELATEDESTATEID` / `RELATEDPROJECTIDS` constants to the `OnOfficeParameterConst` trait.
- Extracts the shared relation block into a single private `relatedParameters()` helper referenced by all three call sites.

## Why

The package centralizes onOffice request parameter names in the `OnOfficeParameterConst` trait (exposed via `OnOfficeService::*`), and #62 deliberately routed the entity-id / relation keys for the file, activity, macro, estate-picture and search-criteria builders through it. `TaskBuilder` was simply missed by that sweep, leaving the same magic strings the rest of the codebase has moved away from — plus a copy-pasted block that meant a future key change had to be made in three places. This is the most glaring remaining instance of the magic-string + duplication pattern the recent refactors (#59, #61, #62, #63) have been systematically eliminating.

## Behavior

Wire values are unchanged — the spread of `relatedParameters()` produces the exact same keyed array that was inlined before, and the surrounding `array_filter(..., fn ($v) => ! is_null($v))` still strips null relations identically. The produced API payloads are byte-for-byte identical.

## Verification

- `composer test` — **627 tests / 842 assertions pass** (including `TaskBuilderTest`'s assertions that the related ids are forwarded at top level on read/create/modify).
- `vendor/bin/pint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtQsN8hrHnrzzafHyRQHSP)_