### PR TITLE
refactor: extract duplicated LogBuilder request parameters into buildParameters()

### DIFF
--- a/src/Query/LogBuilder.php
+++ b/src/Query/LogBuilder.php
@@ -22,9 +22,11 @@ class LogBuilder extends Builder
     public int $userId = -1;
 
     /**
-     * @throws OnOfficeException
+     * Build the shared request parameters used by every terminal method.
+     *
+     * @return array<string, mixed>
      */
-    public function get(): Collection
+    private function buildParameters(): array
     {
         $parameters = [
             OnOfficeService::MODULE => $this->module,
@@ -38,6 +40,16 @@ class LogBuilder extends Builder
         if ($this->userId > 0) {
             $parameters['user'] = $this->userId;
         }
+
+        return $parameters;
+    }
+
+    /**
+     * @throws OnOfficeException
+     */
+    public function get(): Collection
+    {
+        $parameters = $this->buildParameters();
 
         $request = new OnOfficeRequest(
             OnOfficeAction::Read,
@@ -54,18 +66,7 @@ class LogBuilder extends Builder
      */
     public function first(): ?array
     {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
+        $parameters = $this->buildParameters();
 
         $request = new OnOfficeRequest(
             OnOfficeAction::Read,
@@ -98,18 +99,7 @@ class LogBuilder extends Builder
      */
     public function each(callable $callback): void
     {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
+        $parameters = $this->buildParameters();
 
         $request = new OnOfficeRequest(
             OnOfficeAction::Read,
@@ -128,18 +118,7 @@ class LogBuilder extends Builder
      */
     public function count(): int
     {
-        $parameters = [
-            OnOfficeService::MODULE => $this->module,
-            OnOfficeService::ACTION => $this->action,
-            OnOfficeService::FILTER => $this->getFilters(),
-            OnOfficeService::LISTLIMIT => $this->limit,
-            OnOfficeService::LISTOFFSET => $this->offset,
-            ...$this->customParameters,
-        ];
-
-        if ($this->userId > 0) {
-            $parameters['user'] = $this->userId;
-        }
+        $parameters = $this->buildParameters();
 
         $request = new OnOfficeRequest(
             OnOfficeAction::Read,


### PR DESCRIPTION
## What

`LogBuilder`'s four terminal methods — `get()`, `first()`, `each()` and `count()` — each contained the **same 10-line block** building the request parameters array and conditionally appending the `user` filter:

```php
$parameters = [
    OnOfficeService::MODULE => $this->module,
    OnOfficeService::ACTION => $this->action,
    OnOfficeService::FILTER => $this->getFilters(),
    OnOfficeService::LISTLIMIT => $this->limit,
    OnOfficeService::LISTOFFSET => $this->offset,
    ...$this->customParameters,
];

if ($this->userId > 0) {
    $parameters['user'] = $this->userId;
}
```

This PR extracts that block into a single private `buildParameters(): array` helper; each terminal method now calls `$this->buildParameters()`.

## Why

The block was copy-pasted verbatim four times — the parameter shape (and the `user` filter rule) could only be changed correctly by editing all four call sites in lock-step, which is exactly the kind of fragility DRY guards against. This is the same duplication-removal direction as recent builder work in this package (#63 *extract shared `find()`*, #61 *extract shared `FileBuilder` base*); `LogBuilder` was simply the remaining straggler still inlining the shared shape.

## Behaviour

No behavioural change. The helper reproduces the previous array byte-for-byte, so every method sends an identical request. Net diff is **-38 / +17 lines**.

## Verification

- `php -l` — no syntax errors
- `vendor/bin/pint src/Query/LogBuilder.php` — passed
- `vendor/bin/phpstan analyse` (level 8 + larastan) on the file — no errors

> Note: the full `composer test` suite could not be executed in the review sandbox (Pest failed to collect tests there, unrelated to this change), so verification was limited to static analysis and formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PM3hs2aZAQRAjhbC5mbWxi)_