### PR TITLE
fix: harden batch dispatch credentials, faking, and result count

### DIFF
--- a/docs/repositories/query-repository.md
+++ b/docs/repositories/query-repository.md
@@ -55,6 +55,16 @@ Builders are converted to their read request via `toRequest()`, which is availab
 
 A builder's `withCredentials()` apply to the whole batch, since all actions are sent in one API call. Adding builders with different credentials to the same batch throws an `OnOfficeException` — send them as separate batches instead.
 
+Credentials can also be set on the batch itself, which is the only way to send raw `OnOfficeRequest` objects with their own credentials:
+
+```php
+Query::batch([
+    new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+])->withCredentials($token, $secret)->once();
+```
+
+The same conflict rule applies: batch credentials that differ from a builder's credentials throw.
+
 ## Reading a Single Record
 
 Call `withId()` on a builder to read one record by its id instead of a list. It is the batch-friendly counterpart to `find()`:

--- a/docs/repositories/query-repository.md
+++ b/docs/repositories/query-repository.md
@@ -53,6 +53,8 @@ Query::batch()
 
 Builders are converted to their read request via `toRequest()`, which is available on all builders that support `get()` pagination (Estate, Address, Appointment, Task, Activity, User, Last Seen).
 
+A builder's `withCredentials()` apply to the whole batch, since all actions are sent in one API call. Adding builders with different credentials to the same batch throws an `OnOfficeException` — send them as separate batches instead.
+
 ## Reading a Single Record
 
 Call `withId()` on a builder to read one record by its id instead of a list. It is the batch-friendly counterpart to `find()`:
@@ -100,6 +102,8 @@ $estates = data_get($results->firstWhere('identifier', 'estates'), 'data.records
 
 If the batch response or any action inside it fails, an `OnOfficeException` is thrown — the same behavior as single requests. Note that the API may have executed the other actions of the batch regardless. The full response is available via `$exception->getOriginalResponse()` if you need to inspect partial results.
 
+A response that does not contain exactly one result per action also throws an `OnOfficeException`, so a truncated response can never be silently misaligned with the request order.
+
 ## Testing
 
 Faking works like with any other repository. Each page of the faked response becomes one action result, returned in the order the requests were added. Every action is recorded individually, so `assertSentCount()` counts actions (not HTTP calls) and `assertSent()` callbacks receive the individual `OnOfficeRequest` objects:
@@ -135,3 +139,5 @@ test('it reads estates and addresses in one call', function () {
     Query::assertSent(fn (OnOfficeRequest $request) => $request->resourceType === OnOfficeResourceType::Address);
 });
 ```
+
+Batches are faked through `Query::fake()` only — a per-repository fake like `EstateRepository::fake()` is never consumed by a batch. To prevent a mistake here from silently hitting the live API, a batch that contains a builder from a faked (or stray-preventing) repository throws a `StrayRequestException` when the batch itself is not faked. Fake exactly one page per action; a count mismatch throws an `OnOfficeException`.

--- a/docs/repositories/query-repository.md
+++ b/docs/repositories/query-repository.md
@@ -153,3 +153,5 @@ test('it reads estates and addresses in one call', function () {
 ```
 
 Batches are faked through `Query::fake()` only — a per-repository fake like `EstateRepository::fake()` is never consumed by a batch. To prevent a mistake here from silently hitting the live API, a batch that contains a builder from a faked (or stray-preventing) repository throws a `StrayRequestException` when the batch itself is not faked. Fake exactly one page per action; a count mismatch throws an `OnOfficeException`.
+
+To fake a failing action, set `errorCodeResult`/`messageResult` on its page. The top-level `status`/`errorCode`/`message` fields describe the whole response and are taken from the first page only — setting a failing one on a later page throws instead of being silently dropped.

--- a/docs/repositories/query-repository.md
+++ b/docs/repositories/query-repository.md
@@ -70,6 +70,8 @@ $estate = data_get($results[0], 'data.records.0');
 
 `withId()` is the lazy form of a single-record read: it sets the target id and waits. `find($id)` is the eager form of `->withId($id)->first()` — it sends straight away and hands you the record itself, or `null` when it is missing. Reach for `withId()` only when you want to defer the read into `Query::batch()`; otherwise `find()` is more direct.
 
+An id-scoped read carries no paging parameters: the builder's `limit()`, `pageSize()` and `offset()` are ignored, so `withId($id)` sends exactly the request `find($id)` sends — inside a batch or out.
+
 ```php
 EstateRepository::query()->find(5);                 // eager — returns the record
 EstateRepository::query()->withId(5);               // lazy — defer into Query::batch()

--- a/docs/repositories/setting-repository.md
+++ b/docs/repositories/setting-repository.md
@@ -30,10 +30,11 @@ SettingRepository::regions()->each(function (array $regions) {
 
 ## Imprint
 
+The imprint is a single settings record, so `first()` is the way to read it:
+
 ```php
 $imprint = SettingRepository::imprint()->get();
 $imprint = SettingRepository::imprint()->first();
-$imprint = SettingRepository::imprint()->find(1);
 ```
 
 ## Actions
@@ -52,5 +53,5 @@ $actions = SettingRepository::actions()->get();
 |---------|-------|---------|--------|--------|---------|-----------|
 | `users()` | Yes | Yes | Yes | Yes | Yes | Yes |
 | `regions()` | Yes | Yes | No | Yes | No | No |
-| `imprint()` | Yes | Yes | Yes | No | No | No |
+| `imprint()` | Yes | Yes | No | No | No | No |
 | `actions()` | Yes | No | No | No | No | No |

--- a/src/Dtos/OnOfficeApiCredentials.php
+++ b/src/Dtos/OnOfficeApiCredentials.php
@@ -11,4 +11,11 @@ readonly class OnOfficeApiCredentials
         public string $secret,
         public string $apiClaim = ''
     ) {}
+
+    public function equals(self $other): bool
+    {
+        return $this->token === $other->token
+            && $this->secret === $other->secret
+            && $this->apiClaim === $other->apiClaim;
+    }
 }

--- a/src/Dtos/OnOfficeRequest.php
+++ b/src/Dtos/OnOfficeRequest.php
@@ -43,11 +43,8 @@ class OnOfficeRequest
      *
      * @return array<string, mixed>
      */
-    public function toActionArray(): array
+    public function toActionArray(OnOfficeService $onOfficeService): array
     {
-        /** @var OnOfficeService $onOfficeService */
-        $onOfficeService = resolve(OnOfficeService::class);
-
         if (! empty($onOfficeService->getApiClaim())) {
             $this->parameters = array_replace([OnOfficeService::EXTENDEDCLAIM => $onOfficeService->getApiClaim()], $this->parameters);
         }
@@ -73,16 +70,6 @@ class OnOfficeRequest
      */
     public function toRequestArray(): array
     {
-        /** @var OnOfficeService $onOfficeService */
-        $onOfficeService = resolve(OnOfficeService::class);
-
-        return [
-            'token' => $onOfficeService->getToken(),
-            'request' => [
-                'actions' => [
-                    $this->toActionArray(),
-                ],
-            ],
-        ];
+        return resolve(OnOfficeService::class)->requestBody([$this]);
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -153,6 +153,20 @@ class Builder implements BuilderInterface
         return $this;
     }
 
+    public function getCredentials(): ?OnOfficeApiCredentials
+    {
+        return $this->credentials;
+    }
+
+    /**
+     * Whether this builder must not hit the live API: its repository
+     * queued fake responses or opted into stray-request prevention.
+     */
+    public function preventsStrayRequests(): bool
+    {
+        return $this->preventStrayRequests || ($this->stubCallables ?? collect())->isNotEmpty();
+    }
+
     protected function getOnOfficeService(): OnOfficeService
     {
         return tap($this->onOfficeService ?? $this->createOnOfficeService(),

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -722,6 +722,20 @@ class Builder implements BuilderInterface
     }
 
     /**
+     * Send the request and return the first record of the response,
+     * or null when there is none.
+     *
+     * @return array<string, mixed>|null
+     *
+     * @throws OnOfficeException
+     * @throws Throwable
+     */
+    protected function requestFirstRecord(OnOfficeRequest $request): ?array
+    {
+        return $this->requestApi($request)->json(OnOfficeResponsePath::FIRST_RECORD);
+    }
+
+    /**
      * @return array<string, mixed>|null
      *
      * @throws OnOfficeException

--- a/src/Query/Concerns/Paginate.php
+++ b/src/Query/Concerns/Paginate.php
@@ -58,8 +58,7 @@ trait Paginate
      */
     public function find(int|string $id): ?array
     {
-        return $this->requestApi($this->buildFindRequest($id))
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFirstRecord($this->buildFindRequest($id));
     }
 
     /**
@@ -106,7 +105,7 @@ trait Paginate
         $request = $this->readRequest();
         $this->applyListWindow($request, $this->limit > 0 ? $this->limit : $this->pageSize, $this->offset);
 
-        return $this->requestApi($request)->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFirstRecord($request);
     }
 
     /**

--- a/src/Query/Concerns/Paginate.php
+++ b/src/Query/Concerns/Paginate.php
@@ -56,10 +56,26 @@ trait Paginate
      *
      * @throws OnOfficeException
      */
-    public function find(int $id): ?array
+    public function find(int|string $id): ?array
     {
         return $this->requestApi($this->buildFindRequest($id))
             ->json(OnOfficeResponsePath::FIRST_RECORD);
+    }
+
+    /**
+     * An id-scoped read targets exactly one record, so the list window does
+     * not apply. Skipping it keeps a withId() read identical to find() on
+     * the wire.
+     *
+     * @throws OnOfficeException
+     */
+    protected function applyListWindow(OnOfficeRequest $request, int $listLimit, int $offset): void
+    {
+        if ($this->readResourceId !== null) {
+            return;
+        }
+
+        parent::applyListWindow($request, $listLimit, $offset);
     }
 
     /**
@@ -126,10 +142,23 @@ trait Paginate
     public function count(): int
     {
         $request = $this->readRequest();
-        data_set($request->parameters, OnOfficeService::DATA, []);
-        data_set($request->parameters, OnOfficeService::LISTLIMIT, 1);
+
+        if ($this->readResourceId === null) {
+            data_set($request->parameters, OnOfficeService::DATA, []);
+            data_set($request->parameters, OnOfficeService::LISTLIMIT, $this->countListLimit());
+        }
 
         return $this->requestApi($request)->json(OnOfficeResponsePath::META_COUNT_ABSOLUTE, 0);
+    }
+
+    /**
+     * The listlimit a count request is sent with. A count wants no records,
+     * so the smallest page suffices; an endpoint whose cntabsolute misbehaves
+     * at listlimit=1 (the task endpoint) overrides this.
+     */
+    protected function countListLimit(): int
+    {
+        return 1;
     }
 
     /**

--- a/src/Query/ImprintBuilder.php
+++ b/src/Query/ImprintBuilder.php
@@ -14,6 +14,11 @@ use Innobrain\OnOfficeAdapter\Query\Concerns\NonOrderable;
 use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 use Throwable;
 
+/**
+ * The impressum is a singleton settings record (its id is the literal
+ * string "impressum"), so first() is the accessor. There is nothing to
+ * find by id — the API ignores a resource id on this endpoint.
+ */
 class ImprintBuilder extends Builder
 {
     use NonFilterable;
@@ -51,13 +56,5 @@ class ImprintBuilder extends Builder
         );
 
         return $this->requestFirstRecord($request);
-    }
-
-    /**
-     * @throws Throwable<OnOfficeException>
-     */
-    public function find(int $id): ?array
-    {
-        return $this->requestFirstRecord($this->singleRecordRequest(OnOfficeAction::Read, OnOfficeResourceType::Impressum, $id));
     }
 }

--- a/src/Query/ImprintBuilder.php
+++ b/src/Query/ImprintBuilder.php
@@ -11,7 +11,6 @@ use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Query\Concerns\NonFilterable;
 use Innobrain\OnOfficeAdapter\Query\Concerns\NonOrderable;
-use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
 use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
 use Throwable;
 
@@ -51,8 +50,7 @@ class ImprintBuilder extends Builder
             ]
         );
 
-        return $this->requestApi($request)
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFirstRecord($request);
     }
 
     /**
@@ -60,7 +58,6 @@ class ImprintBuilder extends Builder
      */
     public function find(int $id): ?array
     {
-        return $this->requestApi($this->singleRecordRequest(OnOfficeAction::Read, OnOfficeResourceType::Impressum, $id))
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFirstRecord($this->singleRecordRequest(OnOfficeAction::Read, OnOfficeResourceType::Impressum, $id));
     }
 }

--- a/src/Query/PendingBatch.php
+++ b/src/Query/PendingBatch.php
@@ -78,6 +78,26 @@ class PendingBatch
     }
 
     /**
+     * Send the whole batch with these credentials instead of the config
+     * fallback. This is the only way to send raw OnOfficeRequest objects
+     * with their own credentials — builders carry theirs into the batch.
+     * The same rule applies as for builder credentials: a conflict with
+     * credentials already set on the batch throws.
+     *
+     * @throws Throwable
+     */
+    public function withCredentials(string|OnOfficeApiCredentials $token, string $secret = '', string $apiClaim = ''): static
+    {
+        if (! $token instanceof OnOfficeApiCredentials) {
+            $token = new OnOfficeApiCredentials(token: $token, secret: $secret, apiClaim: $apiClaim);
+        }
+
+        $this->useCredentials($token);
+
+        return $this;
+    }
+
+    /**
      * @throws Throwable
      */
     protected function useCredentials(?OnOfficeApiCredentials $credentials): void

--- a/src/Query/PendingBatch.php
+++ b/src/Query/PendingBatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Innobrain\OnOfficeAdapter\Query;
 
 use Illuminate\Support\Collection;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeApiCredentials;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Repositories\BatchRepository;
@@ -25,6 +26,19 @@ class PendingBatch
     protected array $requests = [];
 
     /**
+     * The credentials the batch will be sent with, taken from the
+     * builders that were added. A batch is one API call, so all
+     * requests share them.
+     */
+    protected ?OnOfficeApiCredentials $credentials = null;
+
+    /**
+     * Whether the batch must not hit the live API because a builder
+     * came from a faking or stray-preventing repository.
+     */
+    protected bool $preventStrayRequests = false;
+
+    /**
      * @param  array<int, OnOfficeRequest|Builder>  $requests
      */
     public function __construct(
@@ -40,14 +54,45 @@ class PendingBatch
      *
      * Each request becomes one batch action and returns a single,
      * non-paginated page: the first page only, capped at 500 records.
+     *
+     * A builder's credentials apply to the whole batch, since all
+     * requests are sent in one API call. Builders with different
+     * credentials cannot be batched together.
+     *
+     * @throws Throwable
      */
     public function add(OnOfficeRequest|Builder ...$requests): static
     {
         foreach ($requests as $request) {
-            $this->requests[] = $request instanceof Builder ? $request->toRequest() : $request;
+            if ($request instanceof Builder) {
+                $this->useCredentials($request->getCredentials());
+                $this->preventStrayRequests = $this->preventStrayRequests || $request->preventsStrayRequests();
+
+                $request = $request->toRequest();
+            }
+
+            $this->requests[] = $request;
         }
 
         return $this;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function useCredentials(?OnOfficeApiCredentials $credentials): void
+    {
+        if (is_null($credentials)) {
+            return;
+        }
+
+        throw_if(
+            $this->credentials && ! $this->credentials->equals($credentials),
+            OnOfficeException::class,
+            'All requests in a batch are sent in one API call and cannot use different credentials.',
+        );
+
+        $this->credentials = $credentials;
     }
 
     /**
@@ -64,6 +109,6 @@ class PendingBatch
      */
     public function once(): Collection
     {
-        return $this->repository->dispatch($this->requests);
+        return $this->repository->dispatch($this->requests, $this->credentials, $this->preventStrayRequests);
     }
 }

--- a/src/Query/TaskBuilder.php
+++ b/src/Query/TaskBuilder.php
@@ -39,24 +39,15 @@ class TaskBuilder extends Builder
     protected bool $supportsListOffset = false;
 
     /**
-     * Count matching tasks.
-     *
      * Unlike other resources, the task endpoint's `meta.cntabsolute` equals the
      * number of records returned for the given listlimit rather than the real
-     * total, so the inherited count() (which forces listlimit=1) always returns
-     * 1. Requesting the maximum page size makes cntabsolute reflect the true
+     * total, so counting at the inherited listlimit=1 always returns 1.
+     * Requesting the maximum page size makes cntabsolute reflect the true
      * total, capped at MAX_LIST_LIMIT when more tasks exist.
-     *
-     * @throws OnOfficeException
-     * @throws Throwable
      */
-    public function count(): int
+    protected function countListLimit(): int
     {
-        $request = $this->buildReadRequest();
-        data_set($request->parameters, OnOfficeService::DATA, []);
-        data_set($request->parameters, OnOfficeService::LISTLIMIT, self::MAX_LIST_LIMIT);
-
-        return $this->requestApi($request)->json(OnOfficeResponsePath::META_COUNT_ABSOLUTE, 0);
+        return self::MAX_LIST_LIMIT;
     }
 
     protected function buildReadRequest(): OnOfficeRequest

--- a/src/Repositories/BatchRepository.php
+++ b/src/Repositories/BatchRepository.php
@@ -7,6 +7,7 @@ namespace Innobrain\OnOfficeAdapter\Repositories;
 use GuzzleHttp\Psr7\Response as Psr7Response;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeApiCredentials;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeResponse;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeResponsePage;
@@ -42,18 +43,20 @@ class BatchRepository extends BaseRepository
      * @throws OnOfficeException
      * @throws Throwable
      */
-    public function dispatch(array $requests): Collection
+    public function dispatch(array $requests, ?OnOfficeApiCredentials $credentials = null, bool $preventStrayRequests = false): Collection
     {
         throw_if($requests === [], OnOfficeException::class, 'Cannot send an empty batch');
+
+        $service = $this->onOfficeService($credentials);
 
         $response = $this->stubResponse();
 
         if (is_null($response)) {
-            throw_if($this->preventStrayRequests, StrayRequestException::class, request: $requests[0]);
+            throw_if($this->preventStrayRequests || $preventStrayRequests, StrayRequestException::class, request: $requests[0]);
 
-            $response = $this->onOfficeService()->requestApiBatch($requests);
+            $response = $service->requestApiBatch($requests);
         } else {
-            $this->onOfficeService()->throwIfBatchResponseIsFailed($response);
+            $service->throwIfBatchResponseIsFailed($response, count($requests));
         }
 
         foreach ($requests as $index => $request) {
@@ -66,9 +69,9 @@ class BatchRepository extends BaseRepository
         return collect($results);
     }
 
-    protected function onOfficeService(): OnOfficeService
+    protected function onOfficeService(?OnOfficeApiCredentials $credentials): OnOfficeService
     {
-        return resolve(OnOfficeService::class);
+        return resolve(OnOfficeService::class)->setCredentials($credentials);
     }
 
     /**

--- a/src/Repositories/BatchRepository.php
+++ b/src/Repositories/BatchRepository.php
@@ -59,8 +59,10 @@ class BatchRepository extends BaseRepository
             $service->throwIfBatchResponseIsFailed($response, count($requests));
         }
 
-        foreach ($requests as $index => $request) {
-            $this->recordRequestResponsePair($request, $this->actionResponse($response, $index));
+        if ($this->recording) {
+            foreach ($requests as $index => $request) {
+                $this->recordRequestResponsePair($request, $this->actionResponse($response, $index));
+            }
         }
 
         /** @var array<int, array<string, mixed>> $results */

--- a/src/Repositories/BatchRepository.php
+++ b/src/Repositories/BatchRepository.php
@@ -81,6 +81,7 @@ class BatchRepository extends BaseRepository
      * Each page of the faked response becomes one result of the batch.
      *
      * @throws JsonException
+     * @throws Throwable
      */
     protected function stubResponse(): ?Response
     {
@@ -94,6 +95,16 @@ class BatchRepository extends BaseRepository
         $pages = [];
         while (! $stub->isEmpty()) {
             $pages[] = $stub->shift();
+        }
+
+        foreach (array_slice($pages, 1) as $page) {
+            $status = $page->toStatusArray();
+
+            throw_if(
+                $status['code'] >= 300 || $status['errorcode'] > 0,
+                OnOfficeException::class,
+                'A batch response has a single top-level status, taken from the first faked page. Fail a single action with errorCodeResult/messageResult instead.',
+            );
         }
 
         $body = [

--- a/src/Services/OnOfficeService.php
+++ b/src/Services/OnOfficeService.php
@@ -125,7 +125,7 @@ class OnOfficeService
     public function requestApi(OnOfficeRequest $request): Response
     {
         return $this->post(
-            fn (): array => $request->toRequestArray(),
+            fn (): array => $this->requestBody([$request]),
             fn (Response $response) => $this->throwIfResponseIsFailed($response),
         );
     }
@@ -145,14 +145,27 @@ class OnOfficeService
     public function requestApiBatch(array $requests): Response
     {
         return $this->post(
-            fn (): array => [
-                'token' => $this->getToken(),
-                'request' => [
-                    'actions' => array_map(static fn (OnOfficeRequest $request): array => $request->toActionArray(), $requests),
-                ],
-            ],
+            fn (): array => $this->requestBody($requests),
             fn (Response $response) => $this->throwIfBatchResponseIsFailed($response, count($requests)),
         );
+    }
+
+    /**
+     * The request body envelope: the given actions wrapped with the account
+     * token. Single requests and batches share it — a single request is a
+     * batch of one action.
+     *
+     * @param  array<int, OnOfficeRequest>  $requests
+     * @return array<string, mixed>
+     */
+    public function requestBody(array $requests): array
+    {
+        return [
+            'token' => $this->getToken(),
+            'request' => [
+                'actions' => array_map(fn (OnOfficeRequest $request): array => $request->toActionArray($this), $requests),
+            ],
+        ];
     }
 
     /**

--- a/src/Services/OnOfficeService.php
+++ b/src/Services/OnOfficeService.php
@@ -151,7 +151,7 @@ class OnOfficeService
                     'actions' => array_map(static fn (OnOfficeRequest $request): array => $request->toActionArray(), $requests),
                 ],
             ],
-            fn (Response $response) => $this->throwIfBatchResponseIsFailed($response),
+            fn (Response $response) => $this->throwIfBatchResponseIsFailed($response, count($requests)),
         );
     }
 
@@ -330,18 +330,25 @@ class OnOfficeService
     }
 
     /**
-     * Checks the response status and every result of a
-     * multi-action response for errors.
+     * Checks the response status and every result of a multi-action
+     * response for errors, and that the response contains exactly one
+     * result per action sent.
      *
      * @throws OnOfficeException
      */
-    public function throwIfBatchResponseIsFailed(Response $response): void
+    public function throwIfBatchResponseIsFailed(Response $response, int $expectedResultCount): void
     {
-        $resultCount = max(1, count($response->json('response.results', []) ?? []));
+        $resultCount = count($response->json('response.results', []) ?? []);
 
-        for ($index = 0; $index < $resultCount; $index++) {
+        for ($index = 0; $index < max(1, $resultCount); $index++) {
             $this->throwIfResultIsFailed($response, $index);
         }
+
+        throw_if(
+            $resultCount !== $expectedResultCount,
+            OnOfficeException::class,
+            "Batch response result count ($resultCount) does not match the number of actions sent ($expectedResultCount).",
+        );
     }
 
     /**

--- a/tests/Query/TaskBuilderTest.php
+++ b/tests/Query/TaskBuilderTest.php
@@ -240,6 +240,18 @@ describe('count', function () {
 
         expect($builder->setRepository(new TaskRepository)->count())->toBe(13);
     });
+
+    it('scopes count() to the targeted record when withId() is set', function () {
+        $builder = new TaskBuilder;
+        $builder->setRepository(new TaskRepository)->withId(42)->count();
+
+        Http::assertSent(function (Illuminate\Http\Client\Request $request) {
+            $body = json_decode($request->body(), true);
+
+            return data_get($body, 'request.actions.0.resourceid') === 42
+                && ! array_key_exists('listlimit', data_get($body, 'request.actions.0.parameters', []));
+        });
+    });
 });
 
 describe('listoffset', function () {

--- a/tests/Repositories/EstateRepositoryTest.php
+++ b/tests/Repositories/EstateRepositoryTest.php
@@ -58,6 +58,39 @@ describe('fake responses', function () {
 
         EstateRepository::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 5);
     });
+
+    test('withId and find send the same request', function () {
+        EstateRepository::fake([
+            EstateRepository::response([
+                EstateRepository::page(recordFactories: [
+                    EstateFactory::make()->id(5),
+                ]),
+            ]),
+            EstateRepository::response([
+                EstateRepository::page(recordFactories: [
+                    EstateFactory::make()->id(5),
+                ]),
+            ]),
+        ]);
+
+        EstateRepository::query()->find(5);
+        EstateRepository::query()->withId(5)->first();
+
+        [$findRequest] = EstateRepository::recorded()[0];
+        [$withIdRequest] = EstateRepository::recorded()[1];
+
+        expect($withIdRequest->toArray())->toBe($findRequest->toArray());
+    });
+
+    test('find accepts a string id', function () {
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(),
+        ]));
+
+        EstateRepository::query()->find('external-1');
+
+        EstateRepository::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 'external-1');
+    });
 });
 
 describe('real responses', function () {

--- a/tests/Repositories/ImprintRepositoryTest.php
+++ b/tests/Repositories/ImprintRepositoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
-use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Facades\SettingRepository;
 use Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories\ImprintFactory;
 use Innobrain\OnOfficeAdapter\Tests\Stubs\GetImprintResponse;
@@ -38,20 +38,9 @@ describe('fake responses', function () {
         expect($response['id'])->toBe(1);
     });
 
-    test('find', function () {
-        SettingRepository::fake(SettingRepository::response([
-            SettingRepository::page(recordFactories: [
-                ImprintFactory::make()
-                    ->id(5),
-            ]),
-        ]));
-
-        $response = SettingRepository::imprint()->find(5);
-
-        expect($response['id'])->toBe(5);
-
-        SettingRepository::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 5);
-    });
+    test('find is not supported', function () {
+        SettingRepository::imprint()->find(1);
+    })->throws(OnOfficeException::class, 'Not implemented');
 });
 
 describe('real responses', function () {

--- a/tests/Repositories/ImprintRepositoryTest.php
+++ b/tests/Repositories/ImprintRepositoryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Facades\SettingRepository;
 use Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories\ImprintFactory;
 use Innobrain\OnOfficeAdapter\Tests\Stubs\GetImprintResponse;
@@ -22,6 +23,34 @@ describe('fake responses', function () {
             ->and($response->first()['id'])->toBe(1);
 
         SettingRepository::assertSentCount(1);
+    });
+
+    test('first', function () {
+        SettingRepository::fake(SettingRepository::response([
+            SettingRepository::page(recordFactories: [
+                ImprintFactory::make()
+                    ->id(1),
+            ]),
+        ]));
+
+        $response = SettingRepository::imprint()->first();
+
+        expect($response['id'])->toBe(1);
+    });
+
+    test('find', function () {
+        SettingRepository::fake(SettingRepository::response([
+            SettingRepository::page(recordFactories: [
+                ImprintFactory::make()
+                    ->id(5),
+            ]),
+        ]));
+
+        $response = SettingRepository::imprint()->find(5);
+
+        expect($response['id'])->toBe(5);
+
+        SettingRepository::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 5);
     });
 });
 

--- a/tests/Repositories/QueryTest.php
+++ b/tests/Repositories/QueryTest.php
@@ -10,6 +10,7 @@ use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
 use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
 use Innobrain\OnOfficeAdapter\Exceptions\StrayRequestException;
+use Innobrain\OnOfficeAdapter\Facades\AddressRepository;
 use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
 use Innobrain\OnOfficeAdapter\Facades\Query;
 use Innobrain\OnOfficeAdapter\Facades\TaskRepository;
@@ -130,6 +131,71 @@ describe('fake responses', function () {
             new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
         ])->once();
     })->throws(OnOfficeException::class, 'Error');
+
+    test('faking fewer pages than batch actions throws', function () {
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+        ]));
+
+        Query::batch([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
+        ])->once();
+    })->throws(OnOfficeException::class, 'Batch response result count (1) does not match the number of actions sent (2).');
+
+    test('faking more pages than batch actions throws', function () {
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+            Query::page(resourceType: OnOfficeResourceType::Address),
+        ]));
+
+        Query::batch([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+        ])->once();
+    })->throws(OnOfficeException::class, 'Batch response result count (2) does not match the number of actions sent (1).');
+
+    test('a builder from a faked repository does not hit the live API', function () {
+        EstateRepository::fake(EstateRepository::response());
+
+        Query::batch([
+            EstateRepository::query()->select('kaufpreis'),
+        ])->once();
+    })->throws(StrayRequestException::class);
+
+    test('a builder from a stray-preventing repository does not hit the live API', function () {
+        EstateRepository::preventStrayRequests();
+
+        Query::batch([
+            EstateRepository::query()->select('kaufpreis'),
+        ])->once();
+    })->throws(StrayRequestException::class);
+
+    test('a builder from a faked repository can be batched when the batch itself is faked', function () {
+        EstateRepository::fake(EstateRepository::response());
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+        ]));
+
+        $results = Query::batch([
+            EstateRepository::query()->select('kaufpreis'),
+        ])->once();
+
+        expect($results)->toHaveCount(1)
+            ->and(data_get($results[0], 'data.records.0.id'))->toBe(1);
+    });
+
+    test('builders with different credentials cannot be batched', function () {
+        Query::batch([
+            EstateRepository::query()->withCredentials('token-a', 'secret-a'),
+            AddressRepository::query()->withCredentials('token-b', 'secret-b'),
+        ]);
+    })->throws(OnOfficeException::class, 'All requests in a batch are sent in one API call and cannot use different credentials.');
 });
 
 describe('real responses', function () {
@@ -244,4 +310,60 @@ describe('real responses', function () {
             new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
         ])->once();
     })->throws(OnOfficeException::class, 'Some error');
+
+    test('a response with fewer results than actions throws', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::response([
+                'status' => ['code' => 200, 'errorcode' => 0, 'message' => 'OK'],
+                'response' => [
+                    'results' => [
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'estate',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        Query::batch([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
+        ])->once();
+    })->throws(OnOfficeException::class, 'Batch response result count (1) does not match the number of actions sent (2).');
+
+    test('builder credentials are used for the whole batch', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::response([
+                'status' => ['code' => 200, 'errorcode' => 0, 'message' => 'OK'],
+                'response' => [
+                    'results' => [
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'estate',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'address',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        Query::batch([
+            EstateRepository::query()->withCredentials('tenant-token', 'tenant-secret'),
+            AddressRepository::query()->withCredentials('tenant-token', 'tenant-secret'),
+        ])->once();
+
+        Http::assertSent(fn (Request $request): bool => data_get($request->data(), 'token') === 'tenant-token');
+    });
 });

--- a/tests/Repositories/QueryTest.php
+++ b/tests/Repositories/QueryTest.php
@@ -192,6 +192,24 @@ describe('fake responses', function () {
             ->and(data_get($results[0], 'data.records.0.id'))->toBe(1);
     });
 
+    test('builders with equal credentials can be batched', function () {
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(2),
+            ]),
+        ]));
+
+        $results = Query::batch([
+            EstateRepository::query()->withCredentials('tenant-token', 'tenant-secret'),
+            EstateRepository::query()->withCredentials('tenant-token', 'tenant-secret'),
+        ])->once();
+
+        expect($results)->toHaveCount(2);
+    });
+
     test('builders with different credentials cannot be batched', function () {
         Query::batch([
             EstateRepository::query()->withCredentials('token-a', 'secret-a'),
@@ -367,5 +385,42 @@ describe('real responses', function () {
         ])->once();
 
         Http::assertSent(fn (Request $request): bool => data_get($request->data(), 'token') === 'tenant-token');
+    });
+
+    test('the api claim is sent with every batch action', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::response([
+                'status' => ['code' => 200, 'errorcode' => 0, 'message' => 'OK'],
+                'response' => [
+                    'results' => [
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'estate',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'address',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        Query::batch([
+            EstateRepository::query()->withCredentials('tenant-token', 'tenant-secret', 'tenant-claim'),
+            AddressRepository::query(),
+        ])->once();
+
+        Http::assertSent(function (Request $request): bool {
+            $actions = data_get($request->data(), 'request.actions');
+
+            return data_get($actions, '0.parameters.extendedclaim') === 'tenant-claim'
+                && data_get($actions, '1.parameters.extendedclaim') === 'tenant-claim';
+        });
     });
 });

--- a/tests/Repositories/QueryTest.php
+++ b/tests/Repositories/QueryTest.php
@@ -134,6 +134,20 @@ describe('fake responses', function () {
         ])->once();
     })->throws(OnOfficeException::class, 'Error');
 
+    test('a failing status on a non-first faked page throws', function () {
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+            Query::page(resourceType: OnOfficeResourceType::Address, status: 500, errorCode: 137, message: 'Error'),
+        ]));
+
+        Query::batch([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
+        ])->once();
+    })->throws(OnOfficeException::class, 'A batch response has a single top-level status, taken from the first faked page. Fail a single action with errorCodeResult/messageResult instead.');
+
     test('faking fewer pages than batch actions throws', function () {
         Query::fake(Query::response([
             Query::page(recordFactories: [

--- a/tests/Repositories/QueryTest.php
+++ b/tests/Repositories/QueryTest.php
@@ -95,7 +95,9 @@ describe('fake responses', function () {
 
         expect(data_get($results[0], 'data.records.0.id'))->toBe(5);
 
-        Query::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 5);
+        Query::assertSent(fn (OnOfficeRequest $request) => $request->resourceId === 5
+            && ! array_key_exists('listlimit', $request->parameters)
+            && ! array_key_exists('listoffset', $request->parameters));
     });
 
     test('batching a non-zero offset on a resource without offset support throws', function () {

--- a/tests/Repositories/QueryTest.php
+++ b/tests/Repositories/QueryTest.php
@@ -216,6 +216,26 @@ describe('fake responses', function () {
             AddressRepository::query()->withCredentials('token-b', 'secret-b'),
         ]);
     })->throws(OnOfficeException::class, 'All requests in a batch are sent in one API call and cannot use different credentials.');
+
+    test('batch credentials cannot conflict with builder credentials', function () {
+        Query::batch([
+            EstateRepository::query()->withCredentials('token-a', 'secret-a'),
+        ])->withCredentials('token-b', 'secret-b');
+    })->throws(OnOfficeException::class, 'All requests in a batch are sent in one API call and cannot use different credentials.');
+
+    test('batch credentials equal to builder credentials are accepted', function () {
+        Query::fake(Query::response([
+            Query::page(recordFactories: [
+                EstateFactory::make()->id(1),
+            ]),
+        ]));
+
+        $results = Query::batch([
+            EstateRepository::query()->withCredentials('tenant-token', 'tenant-secret'),
+        ])->withCredentials('tenant-token', 'tenant-secret')->once();
+
+        expect($results)->toHaveCount(1);
+    });
 });
 
 describe('real responses', function () {
@@ -422,5 +442,31 @@ describe('real responses', function () {
             return data_get($actions, '0.parameters.extendedclaim') === 'tenant-claim'
                 && data_get($actions, '1.parameters.extendedclaim') === 'tenant-claim';
         });
+    });
+
+    test('batch credentials sign raw requests', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::response([
+                'status' => ['code' => 200, 'errorcode' => 0, 'message' => 'OK'],
+                'response' => [
+                    'results' => [
+                        [
+                            'actionid' => OnOfficeAction::Read->value,
+                            'resourcetype' => 'estate',
+                            'data' => ['meta' => ['cntabsolute' => 0], 'records' => []],
+                            'status' => ['errorcode' => 0, 'message' => 'OK'],
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        Query::batch([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+        ])->withCredentials('tenant-token', 'tenant-secret', 'tenant-claim')->once();
+
+        Http::assertSent(fn (Request $request): bool => data_get($request->data(), 'token') === 'tenant-token'
+            && data_get($request->data(), 'request.actions.0.parameters.extendedclaim') === 'tenant-claim');
     });
 });

--- a/tests/Services/OnOfficeServiceTest.php
+++ b/tests/Services/OnOfficeServiceTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeApiCredentials;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
 use Innobrain\OnOfficeAdapter\Enums\OnOfficeError;
@@ -55,6 +56,48 @@ describe('credentials', function () {
         expect($onOfficeService->getToken())->toBe($token)
             ->and($onOfficeService->getSecret())->toBe($secret)
             ->and($onOfficeService->getApiClaim())->toBe($apiClaim);
+    });
+});
+
+describe('request body', function () {
+    it('wraps every action with the token and injects the credential api claim', function () {
+        $onOfficeService = resolve(OnOfficeService::class)->setCredentials(
+            new OnOfficeApiCredentials('tenant-token', 'tenant-secret', 'tenant-claim'),
+        );
+
+        $body = $onOfficeService->requestBody([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Address),
+        ]);
+
+        expect($body['token'])->toBe('tenant-token')
+            ->and(data_get($body, 'request.actions.0.parameters.extendedclaim'))->toBe('tenant-claim')
+            ->and(data_get($body, 'request.actions.1.parameters.extendedclaim'))->toBe('tenant-claim')
+            ->and(data_get($body, 'request.actions.0.hmac'))->not->toBeEmpty();
+    });
+
+    it('injects the api claim from the config when no credentials are set', function () {
+        Config::set([
+            'onoffice.token' => 'config-token',
+            'onoffice.api_claim' => 'config-claim',
+        ]);
+
+        $body = resolve(OnOfficeService::class)->requestBody([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+        ]);
+
+        expect($body['token'])->toBe('config-token')
+            ->and(data_get($body, 'request.actions.0.parameters.extendedclaim'))->toBe('config-claim');
+    });
+
+    it('omits the claim when none is configured', function () {
+        Config::set(['onoffice.api_claim' => '']);
+
+        $body = resolve(OnOfficeService::class)->requestBody([
+            new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate),
+        ]);
+
+        expect(data_get($body, 'request.actions.0.parameters'))->not->toHaveKey('extendedclaim');
     });
 });
 

--- a/workbench/app/Console/Commands/ProbeBatchCommand.php
+++ b/workbench/app/Console/Commands/ProbeBatchCommand.php
@@ -174,6 +174,13 @@ class ProbeBatchCommand extends Command
                 ->withCredentials($realToken, $realSecret)
                 ->get()
                 ->isNotEmpty());
+
+            $this->components->task('batch-level credentials sign raw requests', fn (): bool => Query::batch([
+                new OnOfficeRequest(OnOfficeAction::Read, OnOfficeResourceType::Estate, parameters: [
+                    OnOfficeService::DATA => ['Id'],
+                    OnOfficeService::LISTLIMIT => $limit,
+                ]),
+            ])->withCredentials($realToken, $realSecret)->once()->count() === 1);
         } finally {
             config(['onoffice.token' => $realToken, 'onoffice.secret' => $realSecret]);
         }

--- a/workbench/app/Console/Commands/ProbeBatchCommand.php
+++ b/workbench/app/Console/Commands/ProbeBatchCommand.php
@@ -129,6 +129,71 @@ class ProbeBatchCommand extends Command
             }
         });
 
+        $this->probeCredentials($limit);
+
         return self::SUCCESS;
+    }
+
+    /**
+     * A batch is one API call, so a builder's credentials must sign all of
+     * it. Corrupting the config fallback leaves builder-supplied credentials
+     * as the only way a request can succeed — a pass proves they were used.
+     */
+    private function probeCredentials(int $limit): void
+    {
+        $realToken = (string) config('onoffice.token');
+        $realSecret = (string) config('onoffice.secret');
+
+        config(['onoffice.token' => 'wrong', 'onoffice.secret' => 'wrong']);
+
+        try {
+            $this->components->task('corrupted config fallback fails a batch (control)', function () use ($limit): bool {
+                try {
+                    Query::batch([EstateRepository::query()->select(['Id'])->limit($limit)])->once();
+
+                    return false;
+                } catch (OnOfficeException) {
+                    return true;
+                }
+            });
+
+            $this->components->task('builder credentials sign the whole batch', function () use ($limit, $realToken, $realSecret): bool {
+                $results = Query::batch([
+                    EstateRepository::query()->select(['Id'])->limit($limit)->withCredentials($realToken, $realSecret),
+                    AddressRepository::query()->select(['Name'])->limit($limit),
+                ])->once();
+
+                return $results->count() === 2
+                    && data_get($results[0], 'resourcetype') === 'estate'
+                    && data_get($results[1], 'resourcetype') === 'address';
+            });
+
+            $this->components->task('single eager request signs with builder credentials', fn (): bool => EstateRepository::query()
+                ->select(['Id'])
+                ->limit($limit)
+                ->withCredentials($realToken, $realSecret)
+                ->get()
+                ->isNotEmpty());
+        } finally {
+            config(['onoffice.token' => $realToken, 'onoffice.secret' => $realSecret]);
+        }
+
+        $this->components->task('a later batch without credentials falls back to config again', fn (): bool => Query::batch([
+            EstateRepository::query()->select(['Id'])->limit($limit),
+        ])->once()->count() === 1);
+
+        // Guard: mixed builder credentials throw before any HTTP is sent.
+        $this->components->task('different builder credentials cannot be batched', function (): bool {
+            try {
+                Query::batch([
+                    EstateRepository::query()->withCredentials('token-a', 'secret-a'),
+                    AddressRepository::query()->withCredentials('token-b', 'secret-b'),
+                ]);
+
+                return false;
+            } catch (OnOfficeException) {
+                return true;
+            }
+        });
     }
 }

--- a/workbench/app/Console/Commands/ProbeFindCommand.php
+++ b/workbench/app/Console/Commands/ProbeFindCommand.php
@@ -13,6 +13,7 @@ use Innobrain\OnOfficeAdapter\Facades\AppointmentRepository;
 use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
 use Innobrain\OnOfficeAdapter\Facades\LastSeenRepository;
 use Innobrain\OnOfficeAdapter\Facades\Query;
+use Innobrain\OnOfficeAdapter\Facades\SettingRepository;
 use Innobrain\OnOfficeAdapter\Facades\TaskRepository;
 use Innobrain\OnOfficeAdapter\Facades\UserRepository;
 
@@ -36,6 +37,7 @@ class ProbeFindCommand extends Command
             fn () => $this->probeLastSeen(),
             fn () => $this->probeIdScopedShapes(),
             fn () => $this->probeTaskCount(),
+            fn () => $this->probeImprint(),
         ];
 
         // A live failure in one builder must not hide the others.
@@ -197,6 +199,32 @@ class ProbeFindCommand extends Command
         $this->components->task('Task  count()  [quirk, listlimit=500]', fn (): bool => TaskRepository::query()->count() >= 1);
 
         $this->components->task("Task  withId({$id})->count()  [shape]", fn (): bool => TaskRepository::query()->withId($id)->count() === 1);
+    }
+
+    /**
+     * The imprint builder is the one non-Paginate consumer of the shared
+     * single-record combinator (requestFirstRecord), so its first()/find()
+     * need their own live check.
+     */
+    private function probeImprint(): void
+    {
+        $record = null;
+
+        $this->components->task('Imprint  first()  [combinator]', function () use (&$record): bool {
+            $record = SettingRepository::imprint()->first();
+
+            return $record !== null;
+        });
+
+        $id = (int) ($record['id'] ?? 0);
+
+        if ($id === 0) {
+            $this->components->warn('Imprint: record has no id — skipping find()');
+
+            return;
+        }
+
+        $this->components->task("Imprint  find({$id})  [combinator]", fn (): bool => SettingRepository::imprint()->find($id) !== null);
     }
 
     private function firstId(Closure $list): int

--- a/workbench/app/Console/Commands/ProbeFindCommand.php
+++ b/workbench/app/Console/Commands/ProbeFindCommand.php
@@ -34,6 +34,7 @@ class ProbeFindCommand extends Command
             fn () => $this->probeActivity(),
             fn () => $this->probeAppointment(),
             fn () => $this->probeLastSeen(),
+            fn () => $this->probeIdScopedShapes(),
         ];
 
         // A live failure in one builder must not hide the others.
@@ -141,6 +142,38 @@ class ProbeFindCommand extends Command
         $this->components->task('LastSeen  find()  rejects  [guard]', fn (): bool => $this->rejects(fn () => LastSeenRepository::query()->find(1)));
 
         $this->components->task('LastSeen  withId()  rejects  [guard]', fn (): bool => $this->rejects(fn () => LastSeenRepository::query()->withId(1)->get()));
+    }
+
+    /**
+     * Every terminal an id-scoped builder can reach. The list window is
+     * skipped for these reads, so verify the API accepts the bare id read
+     * everywhere and reports usable cntabsolute meta for count()/paginate().
+     */
+    private function probeIdScopedShapes(): void
+    {
+        $id = $this->firstId(fn () => EstateRepository::query()->select(['Id'])->limit(1)->get()->first()['id'] ?? 0);
+
+        if ($id === 0) {
+            $this->components->warn('Estate: no records — skipping id-scoped shapes');
+
+            return;
+        }
+
+        $this->components->task("Estate  withId({$id})->first()  [shape]", fn (): bool => (int) (EstateRepository::query()->withId($id)->first()['id'] ?? 0) === $id);
+
+        $this->components->task("Estate  withId({$id})->get()  [shape]", function () use ($id): bool {
+            $records = EstateRepository::query()->withId($id)->get();
+
+            return $records->count() === 1 && (int) $records->first()['id'] === $id;
+        });
+
+        $this->components->task("Estate  withId({$id})->count()  [shape]", fn (): bool => EstateRepository::query()->withId($id)->count() === 1);
+
+        $this->components->task("Estate  withId({$id})->paginate()  [shape]", function () use ($id): bool {
+            $paginator = EstateRepository::query()->withId($id)->paginate();
+
+            return $paginator->total() === 1 && (int) data_get($paginator->items(), '0.id') === $id;
+        });
     }
 
     private function firstId(Closure $list): int

--- a/workbench/app/Console/Commands/ProbeFindCommand.php
+++ b/workbench/app/Console/Commands/ProbeFindCommand.php
@@ -35,6 +35,7 @@ class ProbeFindCommand extends Command
             fn () => $this->probeAppointment(),
             fn () => $this->probeLastSeen(),
             fn () => $this->probeIdScopedShapes(),
+            fn () => $this->probeTaskCount(),
         ];
 
         // A live failure in one builder must not hide the others.
@@ -174,6 +175,28 @@ class ProbeFindCommand extends Command
 
             return $paginator->total() === 1 && (int) data_get($paginator->items(), '0.id') === $id;
         });
+
+        $this->components->task("Estate  find('{$id}')  [string id]", fn (): bool => (int) (EstateRepository::query()->find((string) $id)['id'] ?? 0) === $id);
+    }
+
+    /**
+     * The task endpoint's count() quirk (cntabsolute mirrors listlimit) and
+     * its id-scoped form both go through readRequest() now — confirm both
+     * still answer sensibly.
+     */
+    private function probeTaskCount(): void
+    {
+        $id = $this->firstId(fn () => TaskRepository::query()->limit(1)->get()->first()['id'] ?? 0);
+
+        if ($id === 0) {
+            $this->components->warn('Task: no records — skipping count shapes');
+
+            return;
+        }
+
+        $this->components->task('Task  count()  [quirk, listlimit=500]', fn (): bool => TaskRepository::query()->count() >= 1);
+
+        $this->components->task("Task  withId({$id})->count()  [shape]", fn (): bool => TaskRepository::query()->withId($id)->count() === 1);
     }
 
     private function firstId(Closure $list): int

--- a/workbench/app/Console/Commands/ProbeFindCommand.php
+++ b/workbench/app/Console/Commands/ProbeFindCommand.php
@@ -203,10 +203,9 @@ class ProbeFindCommand extends Command
 
     /**
      * The imprint builder is the one non-Paginate consumer of the shared
-     * single-record combinator (requestFirstRecord), so its first()/find()
-     * need their own live check. The impressum is a singleton settings
-     * record whose id is the string "impressum" — there is nothing to find
-     * by numeric id, so this also records what the API does with one.
+     * single-record combinator (requestFirstRecord). The impressum is a
+     * singleton settings record whose id is the string "impressum", so
+     * first() is the accessor and find() is not offered.
      */
     private function probeImprint(): void
     {
@@ -220,7 +219,7 @@ class ProbeFindCommand extends Command
 
         $this->components->task('Imprint  record id is the string "impressum"', fn (): bool => ($record['id'] ?? null) === 'impressum');
 
-        $this->components->task('Imprint  find(1)  [API ignores the id, returns the singleton]', fn (): bool => (SettingRepository::imprint()->find(1)['id'] ?? null) === 'impressum');
+        $this->components->task('Imprint  find()  rejects  [guard]', fn (): bool => $this->rejects(fn () => SettingRepository::imprint()->find(1)));
     }
 
     private function firstId(Closure $list): int

--- a/workbench/app/Console/Commands/ProbeFindCommand.php
+++ b/workbench/app/Console/Commands/ProbeFindCommand.php
@@ -204,7 +204,9 @@ class ProbeFindCommand extends Command
     /**
      * The imprint builder is the one non-Paginate consumer of the shared
      * single-record combinator (requestFirstRecord), so its first()/find()
-     * need their own live check.
+     * need their own live check. The impressum is a singleton settings
+     * record whose id is the string "impressum" — there is nothing to find
+     * by numeric id, so this also records what the API does with one.
      */
     private function probeImprint(): void
     {
@@ -216,15 +218,9 @@ class ProbeFindCommand extends Command
             return $record !== null;
         });
 
-        $id = (int) ($record['id'] ?? 0);
+        $this->components->task('Imprint  record id is the string "impressum"', fn (): bool => ($record['id'] ?? null) === 'impressum');
 
-        if ($id === 0) {
-            $this->components->warn('Imprint: record has no id — skipping find()');
-
-            return;
-        }
-
-        $this->components->task("Imprint  find({$id})  [combinator]", fn (): bool => SettingRepository::imprint()->find($id) !== null);
+        $this->components->task('Imprint  find(1)  [API ignores the id, returns the singleton]', fn (): bool => (SettingRepository::imprint()->find(1)['id'] ?? null) === 'impressum');
     }
 
     private function firstId(Closure $list): int


### PR DESCRIPTION
- Apply builder credentials to the whole batch and reset the scoped
  service credentials on dispatch; builders with different credentials
  cannot be batched together
- Throw a StrayRequestException when a batch contains a builder from a
  faked or stray-preventing repository and the batch itself is not faked
- Validate that a batch response contains exactly one result per action,
  on both the real and the faked path