### PR TITLE
fix(builders): encode orderBy() consistently so sort direction survives

### DIFF
--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -31,8 +31,6 @@ class ActivityBuilder extends Builder
 
     protected function buildReadRequest(): OnOfficeRequest
     {
-        $orderBy = $this->getOrderBy();
-
         return new OnOfficeRequest(
             OnOfficeAction::Read,
             OnOfficeResourceType::Activity,
@@ -40,8 +38,7 @@ class ActivityBuilder extends Builder
                 ...$this->prepareEstateOrAddressParameters(),
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => data_get(array_keys($orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($orderBy, 0),
+                ...$this->getSortByParameter(),
                 ...$this->customParameters,
             ]
         );

--- a/src/Query/AddressBuilder.php
+++ b/src/Query/AddressBuilder.php
@@ -32,7 +32,7 @@ class AddressBuilder extends Builder
                 OnOfficeService::RECORDIDS => $this->recordIds,
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                ...$this->getSortByParameter(),
+                ...$this->getSplitSortParameters(),
                 ...$this->customParameters,
             ],
         );
@@ -91,7 +91,7 @@ class AddressBuilder extends Builder
             OnOfficeResourceId::Address,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                ...$this->getSortByParameter(),
+                ...$this->getSplitSortParameters(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/src/Query/AddressBuilder.php
+++ b/src/Query/AddressBuilder.php
@@ -25,8 +25,6 @@ class AddressBuilder extends Builder
 
     protected function buildReadRequest(): OnOfficeRequest
     {
-        $orderBy = $this->getOrderBy();
-
         return new OnOfficeRequest(
             OnOfficeAction::Read,
             OnOfficeResourceType::Address,
@@ -34,8 +32,7 @@ class AddressBuilder extends Builder
                 OnOfficeService::RECORDIDS => $this->recordIds,
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => data_get(array_keys($orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($orderBy, 0),
+                ...$this->getSortByParameter(),
                 ...$this->customParameters,
             ],
         );
@@ -94,8 +91,7 @@ class AddressBuilder extends Builder
             OnOfficeResourceId::Address,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                OnOfficeService::SORTBY => data_get(array_keys($this->orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($this->orderBy, 0),
+                ...$this->getSortByParameter(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -637,6 +637,23 @@ class Builder implements BuilderInterface
         })->all();
     }
 
+    /**
+     * The sort parameter for a read or search request.
+     *
+     * onOffice expects `sortby` as a `{column: direction}` map, which also
+     * preserves multi-column ordering. Centralising the encoding here keeps
+     * every builder consistent instead of each one hand-rolling
+     * `sortby`/`sortorder` from the raw order-by state.
+     *
+     * @return array<string, array<string, string>>
+     */
+    protected function getSortByParameter(): array
+    {
+        return [
+            OnOfficeService::SORTBY => $this->getOrderBy(),
+        ];
+    }
+
     public function parameter(string $key, mixed $value): static
     {
         $this->customParameters[$key] = $value;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -638,12 +638,11 @@ class Builder implements BuilderInterface
     }
 
     /**
-     * The sort parameter for a read or search request.
-     *
-     * onOffice expects `sortby` as a `{column: direction}` map, which also
-     * preserves multi-column ordering. Centralising the encoding here keeps
-     * every builder consistent instead of each one hand-rolling
-     * `sortby`/`sortorder` from the raw order-by state.
+     * The sort parameter for endpoints that take `sortby` as a
+     * `{column: direction}` map: the estate, user and activity reads. This is
+     * the only encoding that preserves multi-column ordering, but it is not
+     * universal — the address read silently ignores it and the search
+     * endpoints reject it, so those use getSplitSortParameters() instead.
      *
      * @return array<string, array<string, string>>
      */
@@ -651,6 +650,26 @@ class Builder implements BuilderInterface
     {
         return [
             OnOfficeService::SORTBY => $this->getOrderBy(),
+        ];
+    }
+
+    /**
+     * The sort parameters for endpoints that take `sortby` as a column name
+     * with the direction in a separate `sortorder`: the address read (which
+     * silently ignores the map form) and the search endpoints (which reject
+     * it). This encoding can only express a single sort column.
+     *
+     * @return array<string, string|null>
+     */
+    protected function getSplitSortParameters(): array
+    {
+        $orderBy = $this->getOrderBy();
+
+        $column = array_key_first($orderBy);
+
+        return [
+            OnOfficeService::SORTBY => $column,
+            OnOfficeService::SORTORDER => $column === null ? null : $orderBy[$column],
         ];
     }
 

--- a/src/Query/EstateBuilder.php
+++ b/src/Query/EstateBuilder.php
@@ -29,7 +29,7 @@ class EstateBuilder extends Builder
             parameters: [
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => $this->getOrderBy(),
+                ...$this->getSortByParameter(),
                 ...$this->customParameters,
             ]
         );
@@ -94,8 +94,7 @@ class EstateBuilder extends Builder
             OnOfficeResourceId::Estate,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                OnOfficeService::SORTBY => data_get(array_keys($this->orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($this->orderBy, 0),
+                ...$this->getSortByParameter(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/src/Query/EstateBuilder.php
+++ b/src/Query/EstateBuilder.php
@@ -94,7 +94,7 @@ class EstateBuilder extends Builder
             OnOfficeResourceId::Estate,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                ...$this->getSortByParameter(),
+                ...$this->getSplitSortParameters(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/src/Query/UserBuilder.php
+++ b/src/Query/UserBuilder.php
@@ -22,7 +22,7 @@ class UserBuilder extends Builder
             parameters: [
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => $this->getOrderBy(),
+                ...$this->getSortByParameter(),
                 ...$this->customParameters,
             ],
         );

--- a/tests/Query/OrderByEncodingTest.php
+++ b/tests/Query/OrderByEncodingTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
+use Innobrain\OnOfficeAdapter\Facades\ActivityRepository;
+use Innobrain\OnOfficeAdapter\Facades\AddressRepository;
+use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
+use Innobrain\OnOfficeAdapter\Facades\UserRepository;
+
+/**
+ * Every builder must encode orderBy() the same way: onOffice expects `sortby`
+ * as a `{column: direction}` map. Previously Address/Activity reads dropped the
+ * direction (sortorder was always null) and the search() methods emitted an
+ * integer sortby, so the caller's sort direction was silently lost.
+ */
+describe('orderBy sortby encoding', function () {
+    it('sends the direction as a sortby map for estate reads', function () {
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(),
+        ]));
+
+        EstateRepository::query()->orderByDesc('kaufpreis')->get();
+
+        EstateRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('sends the direction as a sortby map for address reads', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()->orderByDesc('kaufpreis')->get();
+
+        AddressRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('sends the direction as a sortby map for activity reads', function () {
+        ActivityRepository::fake(ActivityRepository::response([
+            ActivityRepository::page(),
+        ]));
+
+        ActivityRepository::query()->orderByDesc('date')->get();
+
+        ActivityRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['date' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('sends the direction as a sortby map for user reads', function () {
+        UserRepository::fake(UserRepository::response([
+            UserRepository::page(),
+        ]));
+
+        UserRepository::query()->orderByDesc('Name')->get();
+
+        UserRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['Name' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('sends the direction as a sortby map for estate search', function () {
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(),
+        ]));
+
+        EstateRepository::query()->setInput('foo')->orderByDesc('kaufpreis')->search();
+
+        EstateRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('sends the direction as a sortby map for address search', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()->setInput('foo')->orderByDesc('kaufpreis')->search();
+
+        AddressRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
+                && ! array_key_exists('sortorder', $request->parameters);
+        });
+    });
+
+    it('preserves every column when ordering by more than one', function () {
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(),
+        ]));
+
+        EstateRepository::query()
+            ->orderByDesc('kaufpreis')
+            ->orderBy('ort')
+            ->get();
+
+        EstateRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === [
+                'kaufpreis' => 'DESC',
+                'ort' => 'ASC',
+            ];
+        });
+    });
+});

--- a/tests/Query/OrderByEncodingTest.php
+++ b/tests/Query/OrderByEncodingTest.php
@@ -9,10 +9,13 @@ use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
 use Innobrain\OnOfficeAdapter\Facades\UserRepository;
 
 /**
- * Every builder must encode orderBy() the same way: onOffice expects `sortby`
- * as a `{column: direction}` map. Previously Address/Activity reads dropped the
- * direction (sortorder was always null) and the search() methods emitted an
- * integer sortby, so the caller's sort direction was silently lost.
+ * onOffice's sort encoding differs per endpoint (verified against the live
+ * API): estate, user and activity reads take `sortby` as a `{column: direction}`
+ * map, while the address read silently ignores that map and the search
+ * endpoints reject it outright — those need `sortby` as a column name with the
+ * direction in a separate `sortorder`. Previously Address/Activity reads
+ * dropped the direction and the search() methods emitted an integer sortby,
+ * so the caller's sort direction was silently lost.
  */
 describe('orderBy sortby encoding', function () {
     it('sends the direction as a sortby map for estate reads', function () {
@@ -28,28 +31,15 @@ describe('orderBy sortby encoding', function () {
         });
     });
 
-    it('sends the direction as a sortby map for address reads', function () {
-        AddressRepository::fake(AddressRepository::response([
-            AddressRepository::page(),
-        ]));
-
-        AddressRepository::query()->orderByDesc('kaufpreis')->get();
-
-        AddressRepository::assertSent(function (OnOfficeRequest $request) {
-            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
-                && ! array_key_exists('sortorder', $request->parameters);
-        });
-    });
-
     it('sends the direction as a sortby map for activity reads', function () {
         ActivityRepository::fake(ActivityRepository::response([
             ActivityRepository::page(),
         ]));
 
-        ActivityRepository::query()->orderByDesc('date')->get();
+        ActivityRepository::query()->orderByDesc('Datum')->get();
 
         ActivityRepository::assertSent(function (OnOfficeRequest $request) {
-            return $request->parameters['sortby'] === ['date' => 'DESC']
+            return $request->parameters['sortby'] === ['Datum' => 'DESC']
                 && ! array_key_exists('sortorder', $request->parameters);
         });
     });
@@ -67,7 +57,20 @@ describe('orderBy sortby encoding', function () {
         });
     });
 
-    it('sends the direction as a sortby map for estate search', function () {
+    it('sends the column and direction separately for address reads', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()->orderByDesc('KdNr')->get();
+
+        AddressRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === 'KdNr'
+                && $request->parameters['sortorder'] === 'DESC';
+        });
+    });
+
+    it('sends the column and direction separately for estate search', function () {
         EstateRepository::fake(EstateRepository::response([
             EstateRepository::page(),
         ]));
@@ -75,21 +78,34 @@ describe('orderBy sortby encoding', function () {
         EstateRepository::query()->setInput('foo')->orderByDesc('kaufpreis')->search();
 
         EstateRepository::assertSent(function (OnOfficeRequest $request) {
-            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
-                && ! array_key_exists('sortorder', $request->parameters);
+            return $request->parameters['sortby'] === 'kaufpreis'
+                && $request->parameters['sortorder'] === 'DESC';
         });
     });
 
-    it('sends the direction as a sortby map for address search', function () {
+    it('sends the column and direction separately for address search', function () {
         AddressRepository::fake(AddressRepository::response([
             AddressRepository::page(),
         ]));
 
-        AddressRepository::query()->setInput('foo')->orderByDesc('kaufpreis')->search();
+        AddressRepository::query()->setInput('foo')->orderByDesc('KdNr')->search();
 
         AddressRepository::assertSent(function (OnOfficeRequest $request) {
-            return $request->parameters['sortby'] === ['kaufpreis' => 'DESC']
-                && ! array_key_exists('sortorder', $request->parameters);
+            return $request->parameters['sortby'] === 'KdNr'
+                && $request->parameters['sortorder'] === 'DESC';
+        });
+    });
+
+    it('sends null sort parameters for an unordered address read', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()->get();
+
+        AddressRepository::assertSent(function (OnOfficeRequest $request) {
+            return $request->parameters['sortby'] === null
+                && $request->parameters['sortorder'] === null;
         });
     });
 

--- a/workbench/app/Console/Commands/ProbeOrderByCommand.php
+++ b/workbench/app/Console/Commands/ProbeOrderByCommand.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Console\Commands;
+
+use Closure;
+use Illuminate\Console\Command;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
+use Innobrain\OnOfficeAdapter\Facades\ActivityRepository;
+use Innobrain\OnOfficeAdapter\Facades\AddressRepository;
+use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
+use Innobrain\OnOfficeAdapter\Facades\UserRepository;
+use Innobrain\OnOfficeAdapter\Query\Builder;
+
+/**
+ * Which sortby encoding does the live API actually accept, per endpoint?
+ *
+ * builder default      - whatever the builder emits for orderByDesc().
+ * `sortby` map         - {column: direction}, forced via parameter().
+ * `sortby` + sortorder - column name as a string, direction alongside it.
+ *
+ * Estate, user and activity reads honour only the map; the address read and
+ * both search endpoints honour only the split form (the searches reject the
+ * map outright). The builder default row must read DESC OK on every endpoint.
+ */
+class ProbeOrderByCommand extends Command
+{
+    protected $signature = 'probe:order-by {--limit=6}';
+
+    protected $description = 'Probe which sortby encoding the live onOffice API honours, per endpoint.';
+
+    public function handle(): int
+    {
+        $estateId = (int) (EstateRepository::query()->select(['Id'])->limit(1)->get()->first()['id'] ?? 0);
+
+        $endpoints = [
+            'Estate read' => fn () => EstateRepository::query()->select(['Id']),
+            'Address read' => fn () => AddressRepository::query()->select(['KdNr']),
+            'User read' => fn () => UserRepository::query()->select(['Vorname', 'Nachname', 'Emailname']),
+            'Activity read' => fn () => ActivityRepository::query()->estateId($estateId),
+            'Estate search' => fn () => EstateRepository::query()->setInput('a'),
+            'Address search' => fn () => AddressRepository::query()->setInput('a'),
+        ];
+
+        // Each endpoint's column must be one its API actually sorts by:
+        // activities only know fields like Datum, and the address search
+        // silently ignores Id but honours KdNr.
+        $columns = [
+            'Estate read' => 'Id',
+            'Address read' => 'KdNr',
+            'User read' => 'Nachname',
+            'Activity read' => 'Datum',
+            'Estate search' => 'Id',
+            'Address search' => 'KdNr',
+        ];
+
+        foreach ($endpoints as $label => $factory) {
+            $this->newLine();
+            $this->components->info($label);
+
+            $column = $columns[$label];
+            $search = str_contains($label, 'search');
+
+            $this->report('  builder default', $factory, $column, $search, fn (Builder $q) => $q);
+
+            $this->report('  sortby map', $factory, $column, $search, fn (Builder $q) => $q
+                ->parameter('sortby', [$column => 'DESC'])
+                ->parameter('sortorder', null));
+
+            $this->report('  sortby + sortorder', $factory, $column, $search, fn (Builder $q) => $q
+                ->parameter('sortby', $column)
+                ->parameter('sortorder', 'DESC'));
+        }
+
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Ask for DESC and report what actually came back.
+     *
+     * @param  Closure(): Builder  $factory
+     * @param  Closure(Builder): Builder  $encode
+     */
+    private function report(string $label, Closure $factory, string $column, bool $search, Closure $encode): void
+    {
+        $limit = (int) $this->option('limit');
+
+        try {
+            $query = $encode($factory()->orderByDesc($column)->limit($limit));
+
+            $records = ($search ? $query->search() : $query->get())->take($limit);
+        } catch (OnOfficeException $e) {
+            $this->line(sprintf('%s  <fg=red>ERROR</>  %s', $label, $e->getMessage()));
+
+            return;
+        }
+
+        $values = $records->map(fn (array $record) => $column === 'Nachname'
+            ? (string) data_get($record, 'elements.Nachname', '')
+            : (int) $record['id'])->values();
+
+        if ($values->count() < 2) {
+            $this->line(sprintf('%s  <fg=yellow>SKIP</>   fewer than 2 records', $label));
+
+            return;
+        }
+
+        $sorted = $values->all() === $values->sortDesc()->values()->all();
+
+        $this->line(sprintf(
+            '%s  %s  %s',
+            $label,
+            $sorted ? '<fg=green>DESC OK  </>' : '<fg=red>NOT SORTED</>',
+            $values->implode(', '),
+        ));
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -13,6 +13,7 @@ use Workbench\App\Console\Commands\ProbeDocsVerify2Command;
 use Workbench\App\Console\Commands\ProbeDocsVerify3Command;
 use Workbench\App\Console\Commands\ProbeDocsVerifyCommand;
 use Workbench\App\Console\Commands\ProbeFindCommand;
+use Workbench\App\Console\Commands\ProbeOrderByCommand;
 use Workbench\App\Console\Commands\ProbeRegionsCommand;
 
 class WorkbenchServiceProvider extends ServiceProvider
@@ -40,6 +41,7 @@ class WorkbenchServiceProvider extends ServiceProvider
                 ProbeDocsVerify2Command::class,
                 ProbeDocsVerify3Command::class,
                 ProbeFindCommand::class,
+                ProbeOrderByCommand::class,
                 ProbeRegionsCommand::class,
             ]);
         }


### PR DESCRIPTION
`orderBy()` was encoded differently in every builder, and most encodings lost the caller's sort direction: Address/Activity reads always sent `sortorder: null`, and both `search()` methods sent `sortby: 0`.

Probing the live API showed onOffice has no universal encoding:

| Endpoint | Accepted encoding |
|---|---|
| Estate / User / Activity read | `sortby: {column: direction}` map |
| Address read | `sortby: <column>` + `sortorder` (map silently ignored) |
| Estate / Address `search()` | `sortby: <column>` + `sortorder` (map is an API error) |

`Builder` now owns both encodings — `getSortByParameter()` (map) and `getSplitSortParameters()` (column + `sortorder`) — and each endpoint uses the one its API honours. The map form preserves multi-column ordering; the split form can express one column only.

**Verified live:** `vendor/bin/testbench probe:order-by` (added in this PR) requests DESC on all six endpoints and confirms the builder's encoding sorts correctly on every one. `tests/Query/OrderByEncodingTest.php` pins the emitted parameters per endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)