### PR TITLE
refactor: route LinkBuilder type key through OnOfficeParameterConst

### DIFF
--- a/src/Query/LinkBuilder.php
+++ b/src/Query/LinkBuilder.php
@@ -61,7 +61,7 @@ class LinkBuilder extends Builder
         ];
 
         if ($this->resourceId === OnOfficeResourceId::AgentsLog) {
-            $parameters['type'] = $this->type->value;
+            $parameters[OnOfficeService::TYPE] = $this->type->value;
         }
 
         return new OnOfficeRequest(

--- a/src/Services/OnOfficeParameterConst.php
+++ b/src/Services/OnOfficeParameterConst.php
@@ -68,4 +68,6 @@ trait OnOfficeParameterConst
     public const MODULE = 'module';
 
     public const ACTION = 'action';
+
+    public const TYPE = 'type';
 }

--- a/tests/Repositories/LinkRepositoryTest.php
+++ b/tests/Repositories/LinkRepositoryTest.php
@@ -54,7 +54,7 @@ describe('toRequest', function () {
             ->type(OnOfficeResourceId::Address)
             ->toRequest();
 
-        expect($request->parameters)->toBe([OnOfficeService::RECORDID => 7, 'type' => 'address']);
+        expect($request->parameters)->toBe([OnOfficeService::RECORDID => 7, OnOfficeService::TYPE => 'address']);
     });
 
     test('link builders can be batched', function () {


### PR DESCRIPTION
## What

Adds a `TYPE` constant to the `OnOfficeParameterConst` trait and uses it in `LinkBuilder::toRequest()` instead of the bare `'type'` string literal.

```diff
- $parameters['type'] = $this->type->value;
+ $parameters[OnOfficeService::TYPE] = $this->type->value;
```

## Why

The package has a clear, maintainer-established convention: **every** onOffice request-parameter key flows through the `OnOfficeParameterConst` single-source-of-truth (exposed as `OnOfficeService::*`). Two dedicated refactors did exactly this and nothing else — #62 ("route builder parameter keys through OnOfficeParameterConst") and #66 ("route TaskBuilder relation keys through OnOfficeParameterConst").

`LinkBuilder::toRequest()` — recently consolidated in #73 — was the one remaining place setting a parameter key with a raw string literal, sitting directly below `OnOfficeService::RECORDID`. This magic string bypasses the convention and can drift from the rest of the codebase independently. Finishing the pattern keeps the key definitions in one place, which is what the constant trait is for.

## Changes

- `src/Services/OnOfficeParameterConst.php` — add `public const TYPE = 'type';`
- `src/Query/LinkBuilder.php` — reference `OnOfficeService::TYPE`
- `tests/Repositories/LinkRepositoryTest.php` — update the existing `toRequest` assertion to use the constant

## Risk

None to behavior. The wire value is unchanged (`'type'`), so request payloads are byte-identical. The existing `includes the type parameter for agentslog links` test already covers this path.

> Note: `composer install` could not authenticate against GitHub in the sandboxed environment, so the test suite was not run locally — CI will exercise it. Changed files pass `php -l`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bbpci2vzLyprhv1g83LEAh)_