### PR TITLE
feat: add estateLanguage endpoint via EstateRepository::languages()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## main
+- feat: add `EstateRepository::languages()` to read an estate's language variants (`EstateRepository::languages(31)->get()`)
 - TODO: Remove old activity repository code in next major release
 
 ## v1.20.0

--- a/docs/repositories/estate-repository.md
+++ b/docs/repositories/estate-repository.md
@@ -126,6 +126,37 @@ Categories: `Titelbild`, `Foto`, `Foto_gross`, `Grundriss`, `Lageplan`, `Epass_S
 
 These are the built-in categories. Customers can define their own, and the API offers no way to enumerate them — custom category names have to be known up front.
 
+## Estate Languages
+
+Read the language variants of a multilingual estate (multi-language module). The resource type is `estateLanguage`.
+
+```php
+$languages = EstateRepository::languages(100)->get();
+$language = EstateRepository::languages(100)->first();
+```
+
+Each variant is its own estate record: `id` is the variant's estate id, `language` is a 3-letter ISO code, and `mainLangId` points to the main variant's id.
+
+```php
+[
+    ['id' => 100, 'type' => 'estateLanguage', 'elements' => ['language' => 'DEU', 'isMain' => true, 'mainLangId' => 100]],
+    ['id' => 101, 'type' => 'estateLanguage', 'elements' => ['language' => 'ENG', 'isMain' => false, 'mainLangId' => 100]],
+]
+```
+
+An estate has a handful of variants at most, so `get()` reads them in a single request — there is no pagination and no `each()`. To read the variants of many estates in one API call, defer the builders into [`Query::batch()`](./query-repository.md):
+
+```php
+use Innobrain\OnOfficeAdapter\Facades\Query;
+
+$results = Query::batch([
+    EstateRepository::languages(100),
+    EstateRepository::languages(200),
+])->once();
+```
+
+To read the translated field contents of a specific variant, query the estate with the `estatelanguage` parameter (see [Custom Parameters](#custom-parameters) below).
+
 ## Custom Parameters
 
 ```php

--- a/docs/repositories/query-repository.md
+++ b/docs/repositories/query-repository.md
@@ -51,7 +51,7 @@ Query::batch()
     ->once();
 ```
 
-Builders are converted to their read request via `toRequest()`, which is available on the Estate, Address, Appointment, Task, Activity, User, Last Seen, Relation, and Link builders.
+Builders are converted to their read request via `toRequest()`, which is available on the Estate, Estate Language, Address, Appointment, Task, Activity, User, Last Seen, Relation, and Link builders.
 
 A builder's `withCredentials()` apply to the whole batch, since all actions are sent in one API call. Adding builders with different credentials to the same batch throws an `OnOfficeException` — send them as separate batches instead.
 

--- a/docs/testing/factories.md
+++ b/docs/testing/factories.md
@@ -306,6 +306,22 @@ EstateRepository::fake(EstateRepository::response([
 $pictures = EstateRepository::pictures(3729)->get();
 ```
 
+### Estate Languages
+
+```php
+use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
+use Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories\EstateLanguageFactory;
+
+EstateRepository::fake(EstateRepository::response([
+    EstateRepository::page(recordFactories: [
+        EstateLanguageFactory::make()->id(100)->language('DEU')->isMain(true)->mainLangId(100),
+        EstateLanguageFactory::make()->id(101)->language('ENG')->isMain(false)->mainLangId(100),
+    ]),
+]));
+
+$languages = EstateRepository::languages(100)->get();
+```
+
 ### Files
 
 Fake the response to an upload. `save()` returns the `tmpUploadId` from the faked response:
@@ -520,6 +536,7 @@ it('fetches active estates for sale', function () {
 | `SearchCriteriaFactory` | - | Buyer search profiles |
 | `RelationFactory` | `idsfromrelation` | Links between records |
 | `EstatePictureFactory` | `estatepictures` | Estate images (includes defaults) |
+| `EstateLanguageFactory` | `estateLanguage` | Estate language variants (includes defaults) |
 | `FileFactory` | `file` | File uploads (has `ok()`/`error()`) |
 | `FileUploadFactory` | - | Upload responses |
 | `FilterFactory` | `filter` | Saved filters |

--- a/src/Enums/OnOfficeResourceType.php
+++ b/src/Enums/OnOfficeResourceType.php
@@ -9,6 +9,7 @@ enum OnOfficeResourceType: string
     case Address = 'address';
     case Estate = 'estate';
     case EstatePictures = 'estatepictures';
+    case EstateLanguage = 'estateLanguage';
     case Fields = 'fields';
     case Filters = 'filters';
     case File = 'file';

--- a/src/Facades/EstateRepository.php
+++ b/src/Facades/EstateRepository.php
@@ -8,6 +8,7 @@ use Innobrain\OnOfficeAdapter\Dtos\OnOfficeResponse;
 use Innobrain\OnOfficeAdapter\Dtos\OnOfficeResponsePage;
 use Innobrain\OnOfficeAdapter\Query\EstateBuilder;
 use Innobrain\OnOfficeAdapter\Query\EstateFileBuilder;
+use Innobrain\OnOfficeAdapter\Query\EstateLanguageBuilder;
 use Innobrain\OnOfficeAdapter\Query\EstatePictureBuilder;
 use Innobrain\OnOfficeAdapter\Repositories\EstateRepository as RootRepository;
 
@@ -17,6 +18,7 @@ use Innobrain\OnOfficeAdapter\Repositories\EstateRepository as RootRepository;
  * @method static EstateBuilder query()
  * @method static EstateFileBuilder files(int $estateId)
  * @method static EstatePictureBuilder pictures(int|array<int, int> $estateId)
+ * @method static EstateLanguageBuilder languages(int $estateId)
  */
 class EstateRepository extends BaseRepository
 {

--- a/src/Facades/Testing/RecordFactories/EstateLanguageFactory.php
+++ b/src/Facades/Testing/RecordFactories/EstateLanguageFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories;
+
+class EstateLanguageFactory extends BaseFactory
+{
+    public string $type = 'estateLanguage';
+
+    public array $elements = [
+        'language' => 'DEU',
+        'isMain' => true,
+        'mainLangId' => 1,
+    ];
+
+    public function language(string $language): static
+    {
+        $this->elements['language'] = $language;
+
+        return $this;
+    }
+
+    public function isMain(bool $isMain): static
+    {
+        $this->elements['isMain'] = $isMain;
+
+        return $this;
+    }
+
+    public function mainLangId(int $mainLangId): static
+    {
+        $this->elements['mainLangId'] = $mainLangId;
+
+        return $this;
+    }
+}

--- a/src/Query/EstateLanguageBuilder.php
+++ b/src/Query/EstateLanguageBuilder.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Innobrain\OnOfficeAdapter\Query;
+
+use Illuminate\Support\Collection;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
+use Innobrain\OnOfficeAdapter\Query\Concerns\NonFilterable;
+use Innobrain\OnOfficeAdapter\Query\Concerns\NonOrderable;
+use Innobrain\OnOfficeAdapter\Query\Concerns\NonSelectable;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeResponsePath;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
+use Override;
+use Throwable;
+
+/**
+ * An estate has a handful of language variants at most, so this endpoint is read
+ * with a single request rather than through requestAll(): no listlimit is sent and
+ * the API's default page size covers every variant. There is no each() for the same
+ * reason — there is nothing to chunk.
+ */
+class EstateLanguageBuilder extends Builder
+{
+    use NonFilterable;
+    use NonOrderable;
+    use NonSelectable;
+
+    public function __construct(
+        public int $estateId,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws OnOfficeException
+     */
+    public function get(): Collection
+    {
+        /** @var array<int, array<string, mixed>> $records */
+        $records = $this->requestApi($this->toRequest())
+            ->json(OnOfficeResponsePath::RECORDS, []);
+
+        return collect($records);
+    }
+
+    /**
+     * @throws Throwable<OnOfficeException>
+     */
+    public function first(): ?array
+    {
+        return $this->requestApi($this->toRequest())
+            ->json(OnOfficeResponsePath::FIRST_RECORD);
+    }
+
+    /**
+     * Build the estateLanguage request this builder would send, without sending it.
+     * Useful for reading the language variants of many estates in one batched API call.
+     */
+    #[Override]
+    public function toRequest(): OnOfficeRequest
+    {
+        return new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::EstateLanguage,
+            parameters: [
+                OnOfficeService::ESTATEID => $this->estateId,
+                ...$this->customParameters,
+            ],
+        );
+    }
+}

--- a/src/Query/EstateLanguageBuilder.php
+++ b/src/Query/EstateLanguageBuilder.php
@@ -52,8 +52,7 @@ class EstateLanguageBuilder extends Builder
      */
     public function first(): ?array
     {
-        return $this->requestApi($this->toRequest())
-            ->json(OnOfficeResponsePath::FIRST_RECORD);
+        return $this->requestFirstRecord($this->toRequest());
     }
 
     /**

--- a/src/Repositories/EstateRepository.php
+++ b/src/Repositories/EstateRepository.php
@@ -6,6 +6,7 @@ namespace Innobrain\OnOfficeAdapter\Repositories;
 
 use Innobrain\OnOfficeAdapter\Query\EstateBuilder;
 use Innobrain\OnOfficeAdapter\Query\EstateFileBuilder;
+use Innobrain\OnOfficeAdapter\Query\EstateLanguageBuilder;
 use Innobrain\OnOfficeAdapter\Query\EstatePictureBuilder;
 
 class EstateRepository extends BaseRepository
@@ -33,5 +34,14 @@ class EstateRepository extends BaseRepository
     {
         /** @var EstatePictureBuilder */
         return $this->createBuilderFromClass(EstatePictureBuilder::class, $estateId);
+    }
+
+    /**
+     * Returns a new estate language builder instance.
+     */
+    public function languages(int $estateId): EstateLanguageBuilder
+    {
+        /** @var EstateLanguageBuilder */
+        return $this->createBuilderFromClass(EstateLanguageBuilder::class, $estateId);
     }
 }

--- a/tests/Repositories/EstateLanguageRepositoryTest.php
+++ b/tests/Repositories/EstateLanguageRepositoryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeAction;
+use Innobrain\OnOfficeAdapter\Enums\OnOfficeResourceType;
+use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
+use Innobrain\OnOfficeAdapter\Facades\Query;
+use Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories\EstateLanguageFactory;
+use Innobrain\OnOfficeAdapter\Services\OnOfficeService;
+use Innobrain\OnOfficeAdapter\Tests\Stubs\GetEstateLanguagesResponse;
+
+describe('fake responses', function () {
+    test('get', function () {
+        Http::preventStrayRequests();
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(
+                actionId: OnOfficeAction::Get,
+                resourceType: OnOfficeResourceType::EstateLanguage,
+                recordFactories: [
+                    EstateLanguageFactory::make()->id(31)->language('DEU')->isMain(true),
+                    EstateLanguageFactory::make()->id(51)->language('ENG')->isMain(false),
+                    EstateLanguageFactory::make()->id(53)->language('FRA')->isMain(false),
+                ],
+                countAbsolute: 3,
+            ),
+        ]));
+
+        $response = EstateRepository::languages(31)->get();
+
+        expect($response->count())->toBe(3)
+            ->and($response->first()['id'])->toBe(31)
+            ->and($response->first()['type'])->toBe('estateLanguage')
+            ->and($response->pluck('elements.language')->all())->toBe(['DEU', 'ENG', 'FRA']);
+
+        EstateRepository::assertSentCount(1);
+    });
+
+    test('first', function () {
+        Http::preventStrayRequests();
+        EstateRepository::fake(EstateRepository::response([
+            EstateRepository::page(
+                actionId: OnOfficeAction::Get,
+                resourceType: OnOfficeResourceType::EstateLanguage,
+                recordFactories: [
+                    EstateLanguageFactory::make()->id(31)->language('DEU')->isMain(true),
+                    EstateLanguageFactory::make()->id(51)->language('ENG')->isMain(false),
+                ],
+                countAbsolute: 2,
+            ),
+        ]));
+
+        $record = EstateRepository::languages(31)->first();
+
+        expect($record)->toBeArray()
+            ->and($record['id'])->toBe(31)
+            ->and($record['elements']['language'])->toBe('DEU');
+
+        EstateRepository::assertSentCount(1);
+    });
+});
+
+describe('toRequest', function () {
+    test('builds the estateLanguage request without sending it', function () {
+        $request = EstateRepository::languages(31)->toRequest();
+
+        expect($request->actionId)->toBe(OnOfficeAction::Get)
+            ->and($request->resourceType)->toBe(OnOfficeResourceType::EstateLanguage)
+            ->and($request->parameters)->toBe([OnOfficeService::ESTATEID => 31]);
+    });
+
+    test('estate language builders can be batched', function () {
+        Query::fake(Query::response([
+            Query::page(actionId: OnOfficeAction::Get, resourceType: OnOfficeResourceType::EstateLanguage, recordFactories: [
+                EstateLanguageFactory::make()->id(31)->language('DEU'),
+            ]),
+            Query::page(actionId: OnOfficeAction::Get, resourceType: OnOfficeResourceType::EstateLanguage, recordFactories: [
+                EstateLanguageFactory::make()->id(51)->language('ENG'),
+            ]),
+        ]));
+
+        $results = Query::batch([
+            EstateRepository::languages(31),
+            EstateRepository::languages(51),
+        ])->once();
+
+        expect($results)->toHaveCount(2)
+            ->and(data_get($results[0], 'data.records.0.elements.language'))->toBe('DEU')
+            ->and(data_get($results[1], 'data.records.0.elements.language'))->toBe('ENG');
+
+        Query::assertSent(fn (OnOfficeRequest $request) => $request->resourceType === OnOfficeResourceType::EstateLanguage
+            && ($request->parameters[OnOfficeService::ESTATEID] ?? null) === 31);
+        Query::assertSent(fn (OnOfficeRequest $request) => ($request->parameters[OnOfficeService::ESTATEID] ?? null) === 51);
+    });
+});
+
+describe('real responses', function () {
+    test('get returns language records from the response', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => GetEstateLanguagesResponse::make(),
+        ]);
+
+        EstateRepository::record();
+
+        $records = EstateRepository::languages(31)->get();
+
+        expect($records)->toHaveCount(3)
+            ->and($records->pluck('elements.language')->all())->toBe(['DEU', 'ENG', 'FRA']);
+
+        EstateRepository::assertSent(fn (OnOfficeRequest $request) => $request->actionId === OnOfficeAction::Get
+            && $request->resourceType === OnOfficeResourceType::EstateLanguage
+            && ($request->parameters[OnOfficeService::ESTATEID] ?? null) === 31);
+        EstateRepository::assertSentCount(1);
+    });
+
+    test('get does not paginate when the API reports a large absolute count', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::sequence([
+                GetEstateLanguagesResponse::make(cntabsolute: 2000),
+                GetEstateLanguagesResponse::make(cntabsolute: 2000),
+                GetEstateLanguagesResponse::make(cntabsolute: 2000),
+                GetEstateLanguagesResponse::make(cntabsolute: 2000),
+            ]),
+        ]);
+
+        EstateRepository::record();
+
+        $records = EstateRepository::languages(31)->get();
+
+        expect($records)->toHaveCount(3);
+
+        EstateRepository::assertSentCount(1);
+    });
+
+    test('first returns the first language record from the response', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => GetEstateLanguagesResponse::make(),
+        ]);
+
+        EstateRepository::record();
+
+        $record = EstateRepository::languages(31)->first();
+
+        expect($record)->toBeArray()
+            ->and($record['elements']['language'])->toBe('DEU');
+
+        EstateRepository::assertSentCount(1);
+    });
+});

--- a/tests/Stubs/GetEstateLanguagesResponse.php
+++ b/tests/Stubs/GetEstateLanguagesResponse.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Innobrain\OnOfficeAdapter\Tests\Stubs;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use Illuminate\Support\Facades\Http;
+
+class GetEstateLanguagesResponse
+{
+    public static function make(array $data = [], ?int $cntabsolute = null): PromiseInterface
+    {
+        $body = self::getBody($data);
+
+        if ($cntabsolute !== null) {
+            data_set($body, 'response.results.0.data.meta.cntabsolute', $cntabsolute);
+        }
+
+        return Http::response($body);
+    }
+
+    private static function getBody(array $data): array
+    {
+        return array_merge_recursive([
+            'status' => [
+                'code' => 200,
+                'errorcode' => 0,
+                'message' => 'OK',
+            ],
+            'response' => [
+                'results' => [
+                    [
+                        'actionid' => 'urn:onoffice-de-ns:smart:2.5:smartml:action:get',
+                        'resourceid' => '',
+                        'resourcetype' => 'estateLanguage',
+                        'cacheable' => true,
+                        'identifier' => '',
+                        'data' => [
+                            'meta' => [
+                                'cntabsolute' => 3,
+                            ],
+                            'records' => [
+                                [
+                                    'id' => 31,
+                                    'type' => 'estateLanguage',
+                                    'elements' => [
+                                        'language' => 'DEU',
+                                        'isMain' => true,
+                                        'mainLangId' => 31,
+                                    ],
+                                ],
+                                [
+                                    'id' => 51,
+                                    'type' => 'estateLanguage',
+                                    'elements' => [
+                                        'language' => 'ENG',
+                                        'isMain' => false,
+                                        'mainLangId' => 31,
+                                    ],
+                                ],
+                                [
+                                    'id' => 53,
+                                    'type' => 'estateLanguage',
+                                    'elements' => [
+                                        'language' => 'FRA',
+                                        'isMain' => false,
+                                        'mainLangId' => 31,
+                                    ],
+                                ],
+                            ],
+                        ],
+                        'status' => [
+                            'errorcode' => 0,
+                            'message' => 'OK',
+                        ],
+                    ],
+                ],
+            ],
+        ], $data);
+    }
+}

--- a/workbench/app/Console/Commands/ProbeEstateLanguagesCommand.php
+++ b/workbench/app/Console/Commands/ProbeEstateLanguagesCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Workbench\App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Innobrain\OnOfficeAdapter\Exceptions\OnOfficeException;
+use Innobrain\OnOfficeAdapter\Facades\EstateRepository;
+
+class ProbeEstateLanguagesCommand extends Command
+{
+    protected $signature = 'probe:estate-languages
+        {--estate-id= : Estate id to read language variants for. Defaults to the first estate in the tenant.}';
+
+    protected $description = 'Probe the estateLanguage endpoint against the live onOffice API.';
+
+    public function handle(): int
+    {
+        $estateId = $this->resolveEstateId();
+
+        if ($estateId === 0) {
+            $this->components->warn('no estates found — skipping');
+
+            return self::SUCCESS;
+        }
+
+        $records = collect();
+
+        $this->components->task("languages({$estateId})", function () use ($estateId, &$records): void {
+            $records = EstateRepository::languages($estateId)->get();
+        });
+
+        $this->components->info("count: {$records->count()}");
+
+        if ($records->isEmpty()) {
+            $this->components->warn('no language variants returned');
+
+            return self::SUCCESS;
+        }
+
+        $languages = $records->pluck('elements.language')->filter()->values()->all();
+
+        $this->components->info('languages: '.implode(', ', $languages));
+
+        $main = $records->first(fn (array $record): bool => ($record['elements']['isMain'] ?? false) === true);
+
+        if (is_array($main)) {
+            $this->components->info('main language: '.($main['elements']['language'] ?? 'n/a'));
+        }
+
+        $this->components->task('first() returns the same leading record as get()', function () use ($estateId, $records): bool {
+            $first = EstateRepository::languages($estateId)->first();
+
+            return ($first['id'] ?? null) === ($records->first()['id'] ?? null);
+        });
+
+        return self::SUCCESS;
+    }
+
+    private function resolveEstateId(): int
+    {
+        $estateId = (int) ($this->option('estate-id') ?? 0);
+
+        if ($estateId > 0) {
+            return $estateId;
+        }
+
+        try {
+            return (int) (EstateRepository::query()->select(['Id'])->limit(1)->get()->first()['id'] ?? 0);
+        } catch (OnOfficeException) {
+            return 0;
+        }
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -12,6 +12,7 @@ use Workbench\App\Console\Commands\ProbeBatchCommand;
 use Workbench\App\Console\Commands\ProbeDocsVerify2Command;
 use Workbench\App\Console\Commands\ProbeDocsVerify3Command;
 use Workbench\App\Console\Commands\ProbeDocsVerifyCommand;
+use Workbench\App\Console\Commands\ProbeEstateLanguagesCommand;
 use Workbench\App\Console\Commands\ProbeFindCommand;
 use Workbench\App\Console\Commands\ProbeRegionsCommand;
 
@@ -39,6 +40,7 @@ class WorkbenchServiceProvider extends ServiceProvider
                 ProbeDocsVerifyCommand::class,
                 ProbeDocsVerify2Command::class,
                 ProbeDocsVerify3Command::class,
+                ProbeEstateLanguagesCommand::class,
                 ProbeFindCommand::class,
                 ProbeRegionsCommand::class,
             ]);


### PR DESCRIPTION
## Summary

- Add `OnOfficeResourceType::EstateLanguage` and a new `EstateLanguageBuilder` that reads language variants for a given estate via a single GET request (no `listlimit`, no `requestAll()`).
- Expose the builder through `EstateRepository::languages(int $estateId)` and document it on the `EstateRepository` facade.
- Add full test coverage: fake responses, HTTP stubs, request-shape assertions, batch support via `Query::batch()`, and a non-paginating read test.
- Add supporting infrastructure: `EstateLanguageFactory`, `GetEstateLanguagesResponse` stub, and `probe:estate-languages` workbench command for live API verification.

## Usage

```php
$languageCodes = EstateRepository::languages($estateId)
    ->withCredentials($credentials)
    ->get()
    ->pluck('elements.language')
    ->filter()
    ->unique()
    ->values()
    ->all();
```

Batch example:

```php
$results = Query::batch([
    EstateRepository::languages(31),
    EstateRepository::languages(51),
])->once();
```