### PR TITLE
fix: send correct sortorder in read and search requests

### DIFF
--- a/src/Query/ActivityBuilder.php
+++ b/src/Query/ActivityBuilder.php
@@ -31,8 +31,6 @@ class ActivityBuilder extends Builder
 
     protected function buildReadRequest(): OnOfficeRequest
     {
-        $orderBy = $this->getOrderBy();
-
         return new OnOfficeRequest(
             OnOfficeAction::Read,
             OnOfficeResourceType::Activity,
@@ -40,8 +38,8 @@ class ActivityBuilder extends Builder
                 ...$this->prepareEstateOrAddressParameters(),
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => data_get(array_keys($orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($orderBy, 0),
+                OnOfficeService::SORTBY => $this->getSortBy(),
+                OnOfficeService::SORTORDER => $this->getSortOrder(),
                 ...$this->customParameters,
             ]
         );

--- a/src/Query/AddressBuilder.php
+++ b/src/Query/AddressBuilder.php
@@ -25,8 +25,6 @@ class AddressBuilder extends Builder
 
     protected function buildReadRequest(): OnOfficeRequest
     {
-        $orderBy = $this->getOrderBy();
-
         return new OnOfficeRequest(
             OnOfficeAction::Read,
             OnOfficeResourceType::Address,
@@ -34,8 +32,8 @@ class AddressBuilder extends Builder
                 OnOfficeService::RECORDIDS => $this->recordIds,
                 OnOfficeService::DATA => $this->columns,
                 OnOfficeService::FILTER => $this->getFilters(),
-                OnOfficeService::SORTBY => data_get(array_keys($orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($orderBy, 0),
+                OnOfficeService::SORTBY => $this->getSortBy(),
+                OnOfficeService::SORTORDER => $this->getSortOrder(),
                 ...$this->customParameters,
             ],
         );
@@ -94,8 +92,8 @@ class AddressBuilder extends Builder
             OnOfficeResourceId::Address,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                OnOfficeService::SORTBY => data_get(array_keys($this->orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($this->orderBy, 0),
+                OnOfficeService::SORTBY => $this->getSortBy(),
+                OnOfficeService::SORTORDER => $this->getSortOrder(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -637,6 +637,23 @@ class Builder implements BuilderInterface
         })->all();
     }
 
+    /**
+     * The column of the first orderBy entry, for endpoints that expect
+     * a string sortby with a separate sortorder parameter.
+     */
+    protected function getSortBy(): ?string
+    {
+        return data_get($this->orderBy, '0.0');
+    }
+
+    /**
+     * The direction of the first orderBy entry.
+     */
+    protected function getSortOrder(): ?string
+    {
+        return data_get($this->orderBy, '0.1');
+    }
+
     public function parameter(string $key, mixed $value): static
     {
         $this->customParameters[$key] = $value;

--- a/src/Query/EstateBuilder.php
+++ b/src/Query/EstateBuilder.php
@@ -94,8 +94,8 @@ class EstateBuilder extends Builder
             OnOfficeResourceId::Estate,
             parameters: [
                 OnOfficeService::INPUT => $this->input,
-                OnOfficeService::SORTBY => data_get(array_keys($this->orderBy), 0),
-                OnOfficeService::SORTORDER => data_get($this->orderBy, 0),
+                OnOfficeService::SORTBY => $this->getSortBy(),
+                OnOfficeService::SORTORDER => $this->getSortOrder(),
                 OnOfficeService::FILTER => $this->getFilters(),
                 ...$this->customParameters,
             ],

--- a/tests/Repositories/ActivityRepositoryTest.php
+++ b/tests/Repositories/ActivityRepositoryTest.php
@@ -83,3 +83,19 @@ describe('real responses', function () {
         ActivityRepository::assertSentCount(1);
     });
 });
+
+describe('order by', function () {
+    test('get sends the first order by as sortby and sortorder', function () {
+        ActivityRepository::fake(ActivityRepository::response([
+            ActivityRepository::page(),
+        ]));
+
+        ActivityRepository::query()
+            ->orderByDesc('Datum')
+            ->orderBy('Art')
+            ->get();
+
+        ActivityRepository::assertSent(fn (OnOfficeRequest $request) => $request->parameters['sortby'] === 'Datum'
+            && $request->parameters['sortorder'] === 'DESC');
+    });
+});

--- a/tests/Repositories/AddressRepositoryTest.php
+++ b/tests/Repositories/AddressRepositoryTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Http;
+use Innobrain\OnOfficeAdapter\Dtos\OnOfficeRequest;
 use Innobrain\OnOfficeAdapter\Facades\AddressRepository;
 use Innobrain\OnOfficeAdapter\Facades\Testing\RecordFactories\AddressFactory;
 use Innobrain\OnOfficeAdapter\Tests\Stubs\ReadAddressResponse;
@@ -60,5 +61,34 @@ describe('real responses', function () {
         expect($response)->toBe(1500);
 
         AddressRepository::assertSentCount(1);
+    });
+});
+
+describe('order by', function () {
+    test('get sends the first order by as sortby and sortorder', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()
+            ->orderByDesc('KdNr')
+            ->get();
+
+        AddressRepository::assertSent(fn (OnOfficeRequest $request) => $request->parameters['sortby'] === 'KdNr'
+            && $request->parameters['sortorder'] === 'DESC');
+    });
+
+    test('search sends the first order by as sortby and sortorder', function () {
+        AddressRepository::fake(AddressRepository::response([
+            AddressRepository::page(),
+        ]));
+
+        AddressRepository::query()
+            ->setInput('test')
+            ->orderBy('KdNr')
+            ->search();
+
+        AddressRepository::assertSent(fn (OnOfficeRequest $request) => $request->parameters['sortby'] === 'KdNr'
+            && $request->parameters['sortorder'] === 'ASC');
     });
 });

--- a/tests/Repositories/EstateRepositoryTest.php
+++ b/tests/Repositories/EstateRepositoryTest.php
@@ -153,4 +153,23 @@ describe('search', function () {
             && $request->resourceType === OnOfficeResourceType::Search
             && $request->parameters['input'] === 'testInput');
     });
+
+    it('should send the first order by as sortby and sortorder', function () {
+        Http::preventStrayRequests();
+        Http::fake([
+            'https://api.onoffice.de/api/stable/api.php' => Http::sequence([
+                ReadEstateResponse::make(),
+            ]),
+        ]);
+
+        EstateRepository::record();
+
+        EstateRepository::query()
+            ->setInput('testInput')
+            ->orderByDesc('kaufpreis')
+            ->search();
+
+        EstateRepository::assertSent(fn (OnOfficeRequest $request) => $request->parameters['sortby'] === 'kaufpreis'
+            && $request->parameters['sortorder'] === 'DESC');
+    });
 });


### PR DESCRIPTION
## Problem

`Builder::getOrderBy()` returns a column-keyed array, but the activity and address read requests extracted the sort direction with `data_get($orderBy, 0)`, which is always `null`. The address and estate `search()` requests indexed the raw orderBy tuple list the same way, sending `0` as `sortby` and the whole tuple array as `sortorder`.

The API sorts ascending when `sortorder` is null, so `orderByDesc()` returned records in the opposite order (verified against a live tenant).

## Solution

New `getSortBy()` / `getSortOrder()` helpers on the base builder read the column and direction from the first orderBy entry; all four requests use them. The estate and user read requests already send the working object form of `sortby` and are unchanged.

Regression tests assert the exact `sortby` / `sortorder` request parameters for the activity read, address read, address search and estate search requests.