### PR TITLE
refactor: extract duplicated response-rebuild into replaceRecordsAt()

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -331,17 +331,7 @@ class Builder implements BuilderInterface
                 $ids = $response->json(OnOfficeResponsePath::RECORD_IDS, []);
 
                 if ($ids === []) {
-                    $responseBody = $response->json();
-                    data_set($responseBody, $resultPath, []);
-                    $psrResponse = $response->toPsrResponse();
-
-                    return new Response(new Psr7Response(
-                        $psrResponse->getStatusCode(),
-                        $psrResponse->getHeaders(),
-                        json_encode($responseBody, JSON_THROW_ON_ERROR),
-                        $psrResponse->getProtocolVersion(),
-                        $psrResponse->getReasonPhrase(),
-                    ));
+                    return $this->replaceRecordsAt($response, $resultPath, []);
                 }
 
                 $userRightsResponse = BaseRepositoryFacade::query()
@@ -365,22 +355,35 @@ class Builder implements BuilderInterface
 
                 $records = array_filter($records, static fn (array $record): bool => in_array((int) $record['id'], $allowedIds, true));
 
-                $responseBody = $response->json();
-                data_set($responseBody, $resultPath, array_values($records));
-                $psrResponse = $response->toPsrResponse();
-
-                return new Response(new Psr7Response(
-                    $psrResponse->getStatusCode(),
-                    $psrResponse->getHeaders(),
-                    json_encode($responseBody, JSON_THROW_ON_ERROR),
-                    $psrResponse->getProtocolVersion(),
-                    $psrResponse->getReasonPhrase(),
-                ));
+                return $this->replaceRecordsAt($response, $resultPath, array_values($records));
             },
             $action,
             $module,
             $userId,
         ]);
+    }
+
+    /**
+     * Rebuild the response with the records at the given path replaced, leaving
+     * every other field in the response body (e.g. count_absolute) untouched.
+     *
+     * @param  array<int, mixed>  $records
+     *
+     * @throws JsonException
+     */
+    private function replaceRecordsAt(Response $response, string $resultPath, array $records): Response
+    {
+        $responseBody = $response->json();
+        data_set($responseBody, $resultPath, $records);
+        $psrResponse = $response->toPsrResponse();
+
+        return new Response(new Psr7Response(
+            $psrResponse->getStatusCode(),
+            $psrResponse->getHeaders(),
+            json_encode($responseBody, JSON_THROW_ON_ERROR),
+            $psrResponse->getProtocolVersion(),
+            $psrResponse->getReasonPhrase(),
+        ));
     }
 
     /**


### PR DESCRIPTION
## What

`Builder::checkUserRecordsRight()` contained the same five-argument `Psr7Response` reconstruction — read the JSON body, `data_set()` the records at the result path, then rebuild an `Illuminate\Http\Client\Response` around a fresh `Psr7Response` — written out **verbatim in two branches** (the empty-ids short-circuit and the main filtered path). The only difference between the two blocks was the value written at the result path (`[]` vs `array_values($records)`).

This PR extracts that shared logic into a single private helper:

```php
private function replaceRecordsAt(Response $response, string $resultPath, array $records): Response
```

Both branches now read as one-liners:

```php
if ($ids === []) {
    return $this->replaceRecordsAt($response, $resultPath, []);
}
// ...
return $this->replaceRecordsAt($response, $resultPath, array_values($records));
```

## Why

The response shape (status code, headers, protocol version, reason phrase, `JSON_THROW_ON_ERROR` encoding) was defined in two places ~30 lines apart. Any future change — a header tweak, an encoding flag — had to be made in both spots, and the two could silently drift. Defining it once removes that DRY hazard while keeping every non-record field in the response body (e.g. `count_absolute`) untouched, exactly as before.

## Behavior

No behavior change — this is a pure, mechanical extraction of identical code. The existing `check user rights` tests in `tests/Repositories/BaseRepositoryTest.php` exercise the filtering path and assert the record set is narrowed to the allowed ids.

> Note: local `composer install` could not complete in this environment (GitHub authentication failures from the package host), so `pest`/`phpstan`/`pint` were run via CI rather than locally. Happy to iterate on anything CI surfaces.

---
_Generated by [Claude Code](https://claude.ai/code/session_011jTS56mQmQ233KJDYRnadD)_