### PR TITLE
refactor: dedupe FilterBuilder request construction, kill stray magic string

### DIFF
--- a/src/Query/FilterBuilder.php
+++ b/src/Query/FilterBuilder.php
@@ -16,6 +16,10 @@ use Throwable;
 
 class FilterBuilder extends Builder
 {
+    public const MODULE_ESTATE = 'estate';
+
+    public const MODULE_ADDRESS = 'address';
+
     public string $module;
 
     /**
@@ -24,17 +28,7 @@ class FilterBuilder extends Builder
      */
     public function get(): Collection
     {
-        throw_unless(isset($this->module), OnOfficeQueryException::class, 'Filter Builder module is not set');
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::Filters,
-            parameters: [
-                OnOfficeService::MODULE => $this->module,
-            ]
-        );
-
-        return $this->requestAll($request);
+        return $this->requestAll($this->buildRequest());
     }
 
     /**
@@ -43,19 +37,8 @@ class FilterBuilder extends Builder
      */
     public function first(): ?array
     {
-        throw_unless(isset($this->module), OnOfficeQueryException::class, 'Filter Builder module is not set');
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::Filters,
-            parameters: [
-                'module' => $this->module,
-            ]
-        );
-
-        return $this->requestApi($request)
+        return $this->requestApi($this->buildRequest())
             ->json(OnOfficeResponsePath::FIRST_RECORD);
-
     }
 
     /**
@@ -64,30 +47,36 @@ class FilterBuilder extends Builder
      */
     public function each(callable $callback): void
     {
-        throw_unless(isset($this->module), OnOfficeQueryException::class, 'Filter Builder module is not set');
-
-        $request = new OnOfficeRequest(
-            OnOfficeAction::Get,
-            OnOfficeResourceType::Filters,
-            parameters: [
-                OnOfficeService::MODULE => $this->module,
-            ],
-        );
-
-        $this->requestAllChunked($request, $callback);
+        $this->requestAllChunked($this->buildRequest(), $callback);
     }
 
     public function estate(): static
     {
-        $this->module = 'estate';
+        $this->module = self::MODULE_ESTATE;
 
         return $this;
     }
 
     public function address(): static
     {
-        $this->module = 'address';
+        $this->module = self::MODULE_ADDRESS;
 
         return $this;
+    }
+
+    /**
+     * @throws Throwable<OnOfficeQueryException>
+     */
+    private function buildRequest(): OnOfficeRequest
+    {
+        throw_unless(isset($this->module), OnOfficeQueryException::class, 'Filter Builder module is not set');
+
+        return new OnOfficeRequest(
+            OnOfficeAction::Get,
+            OnOfficeResourceType::Filters,
+            parameters: [
+                OnOfficeService::MODULE => $this->module,
+            ],
+        );
     }
 }


### PR DESCRIPTION
## What & why

While auditing the package for deviations from idiomatic Laravel / DRY design, `FilterBuilder` stood out as the most glaring, self-contained one.

Its three terminal methods — `get()`, `first()` and `each()` — each repeated the **identical** `throw_unless(...)` "module is not set" guard and rebuilt an **identical** `Filters` `OnOfficeRequest`. Worse, the three copies had already started to drift: `first()` hard-coded the raw string `'module'` as the parameter key, while `get()` and `each()` correctly used the `OnOfficeService::MODULE` constant.

That stray magic string is exactly the class of drift the package's `OnOfficeParameterConst` / `OnOfficeService::*` constants exist to prevent — and triplicated logic means any future change (or bug) has to be made in three places and can silently diverge, as it already had.

## Change

- Extract a single private `buildRequest(): OnOfficeRequest` that owns the guard **and** the request construction; `get()`/`first()`/`each()` now delegate to it.
- Route the parameter key through `OnOfficeService::MODULE` everywhere (removes the `'module'` magic string in `first()`).
- Promote the `'estate'` / `'address'` module names to named class constants (`MODULE_ESTATE` / `MODULE_ADDRESS`).

**Pure refactor — no behavior change.** `OnOfficeService::MODULE` already resolves to `'module'`, so the emitted request is byte-for-byte identical; the guard message and the `estate()`/`address()` values are preserved.

Net: 25 insertions, 36 deletions.

## Verification

- `vendor/bin/pint` — passed.
- Full test suite — **678 passed (959 assertions)**, including the `FilterBuilder` / `FilterRepository` tests that assert `get()`/`first()`/`each()` throw when the module is unset and that responses paginate correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5iaxU7QCFUwsQaDo2gE6R)_